### PR TITLE
add support for setting TZ environment variable

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,7 +6,8 @@ RUN npm i -g flood --unsafe-perm
 
 # Install runtime dependencies
 RUN apk --no-cache add \
-    mediainfo
+    mediainfo \
+    tzdata
 
 # Create "download" user
 RUN adduser -h /home/download -s /sbin/nologin --disabled-password download

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Or `jesec/flood:master` for cutting-edge builds.
 
 To upgrade, `docker pull jesec/flood`.
 
-Note that you have to let Docker know which port should be exposed (e.g. `-p 3000:3000`) and folder mapping (e.g. `-v /data:/data`).
+Note that you have to let Docker know which port should be exposed (e.g. `-p 3000:3000`), folder mapping (e.g. `-v /data:/data`) and optionally timezone (e.g. `-e TZ=America/New_York`)
 
 Don't forget to pay attention to `flood`'s arguments like `--port` and `--allowedpath`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows people at runtime to set an environment variable of `TZ` to their timezone.

<!--- Describe your changes in detail -->

## Related Issue

Closes https://github.com/jesec/flood/issues/93

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

This is a common pattern seen in other projects that utilize docker containers

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
