### PR TITLE
Add ability to set UID and GID during container runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,16 +37,13 @@ RUN rm /tmp/*.tgz
 
 # Install runtime dependencies
 RUN apk --no-cache add \
-    mediainfo
-
-# Create "download" user
-RUN adduser -h /home/download -s /sbin/nologin --disabled-password download
-
-# Run as "download" user
-USER download
+    mediainfo su-exec
 
 # Expose port 3000
 EXPOSE 3000
 
+# Copy docker entrypoint script
+COPY docker-entrypoint.sh /
+
 # Flood
-ENTRYPOINT ["flood", "--host=0.0.0.0"]
+ENTRYPOINT ["/docker-entrypoint.sh", "flood", "--host=0.0.0.0"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,16 +6,13 @@ RUN npm i -g flood --unsafe-perm
 
 # Install runtime dependencies
 RUN apk --no-cache add \
-    mediainfo
-
-# Create "download" user
-RUN adduser -h /home/download -s /sbin/nologin --disabled-password download
-
-# Run as "download" user
-USER download
+    mediainfo su-exec
 
 # Expose port 3000
 EXPOSE 3000
 
+# Copy docker entrypoint script
+COPY docker-entrypoint.sh /
+
 # Flood
-ENTRYPOINT ["flood", "--host=0.0.0.0"]
+ENTRYPOINT ["/docker-entrypoint.sh", "flood", "--host=0.0.0.0"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+
+FLOOD_USER=${FLOOD_USER:-download}
+
+if [ -n "$FLOOD_UID" ]; then
+    OPTS="-u $FLOOD_UID"
+fi
+
+if [ -n "$FLOOD_GID" ]; then
+    OPTS="$OPTS -G $FLOOD_USER"
+    addgroup -g $FLOOD_GID $FLOOD_USER
+fi
+
+adduser -h /home/download -g $FLOOD_USER -D -s /sbin/nologin $OPTS $FLOOD_USER
+
+exec su-exec $FLOOD_USER "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add ability to set UID and GID during container runtime via env variables.

## Description

<!--- Describe your changes in detail -->
Currently user `download` which is used as a flood process owner is created at image build. It doesn't give much flexibility if we would like to change process UID and GID. Changing those is useful for flood because it heavily rely on filesystem permissions for accessing files which are shared between other processes (rtorrent).
This PR changes the way process owner user is created, instead of creating user at build time it's created at container runtime. This way we can start container with desired UID and GID, e.g.:
```
docker run -it -e FLOOD_UID=2000 -e FLOOD_GID=2000 jesec/flood
```

Setting those env variables is optional.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/jesec/flood/issues/104

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
