### PR TITLE
feature: add support for sequential download

### DIFF
--- a/client/src/javascript/actions/TorrentActions.ts
+++ b/client/src/javascript/actions/TorrentActions.ts
@@ -13,6 +13,7 @@ import type {
   MoveTorrentsOptions,
   SetTorrentContentsPropertiesOptions,
   SetTorrentsPriorityOptions,
+  SetTorrentsSequentialOptions,
   SetTorrentsTrackersOptions,
   StartTorrentsOptions,
   StopTorrentsOptions,
@@ -196,6 +197,19 @@ const TorrentActions = {
   setPriority: (options: SetTorrentsPriorityOptions) =>
     axios
       .patch(`${baseURI}api/torrents/priority`, options)
+      .then((json) => json.data)
+      .then(
+        () => {
+          // do nothing.
+        },
+        () => {
+          // do nothing.
+        },
+      ),
+
+  setSequential: (options: SetTorrentsSequentialOptions) =>
+    axios
+      .patch(`${baseURI}api/torrents/sequential`, options)
       .then((json) => json.data)
       .then(
         () => {

--- a/client/src/javascript/components/general/form-elements/FilesystemBrowserTextbox.tsx
+++ b/client/src/javascript/components/general/form-elements/FilesystemBrowserTextbox.tsx
@@ -15,6 +15,7 @@ interface FilesystemBrowserTextboxProps {
   suggested?: string;
   showBasePathToggle?: boolean;
   showCompletedToggle?: boolean;
+  showSequentialToggle?: boolean;
   onChange?: (destination: string) => void;
 }
 
@@ -27,6 +28,7 @@ const FilesystemBrowserTextbox = forwardRef<HTMLInputElement, FilesystemBrowserT
       suggested,
       showBasePathToggle,
       showCompletedToggle,
+      showSequentialToggle,
       onChange,
     }: FilesystemBrowserTextboxProps,
     ref,
@@ -76,6 +78,14 @@ const FilesystemBrowserTextbox = forwardRef<HTMLInputElement, FilesystemBrowserT
       toggles.push(
         <Checkbox grow={false} id="isCompleted" key="isCompleted">
           <FormattedMessage id="torrents.destination.completed" />
+        </Checkbox>,
+      );
+    }
+    if (showSequentialToggle) {
+      // TODO: this is getting bloated. toggles can be moved to their own elements...
+      toggles.push(
+        <Checkbox grow={false} id="isSequential" key="isSequential">
+          <FormattedMessage id="torrents.destination.sequential" />
         </Checkbox>,
       );
     }
@@ -156,6 +166,7 @@ FilesystemBrowserTextbox.defaultProps = {
   suggested: undefined,
   showBasePathToggle: false,
   showCompletedToggle: false,
+  showSequentialToggle: false,
   onChange: undefined,
 };
 

--- a/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByFile.tsx
+++ b/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByFile.tsx
@@ -19,6 +19,7 @@ interface AddTorrentsByFileFormData {
   tags: string;
   isBasePath: boolean;
   isCompleted: boolean;
+  isSequential: boolean;
 }
 
 const AddTorrentsByFile: FC = () => {
@@ -64,6 +65,7 @@ const AddTorrentsByFile: FC = () => {
         selectable="directories"
         showBasePathToggle
         showCompletedToggle
+        showSequentialToggle
       />
       <AddTorrentsActions
         onAddTorrentsClick={() => {
@@ -74,7 +76,14 @@ const AddTorrentsByFile: FC = () => {
           const formData = formRef.current?.getFormData();
           setIsAddingTorrents(true);
 
-          const {destination, start, tags, isBasePath, isCompleted} = formData as Partial<AddTorrentsByFileFormData>;
+          const {
+            destination,
+            start,
+            tags,
+            isBasePath,
+            isCompleted,
+            isSequential,
+          } = formData as Partial<AddTorrentsByFileFormData>;
 
           const filesData: Array<string> = [];
           filesRef.current.forEach((file) => {
@@ -94,6 +103,7 @@ const AddTorrentsByFile: FC = () => {
             tags: tagsArray,
             isBasePath,
             isCompleted,
+            isSequential,
             start,
           }).then(() => {
             UIStore.dismissModal();

--- a/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByURL.tsx
+++ b/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByURL.tsx
@@ -20,6 +20,7 @@ type AddTorrentsByURLFormData = {
   destination: string;
   isBasePath: boolean;
   isCompleted: boolean;
+  isSequential: boolean;
   start: boolean;
   tags: string;
 };
@@ -99,6 +100,7 @@ const AddTorrentsByURL: FC = () => {
         selectable="directories"
         showBasePathToggle
         showCompletedToggle
+        showSequentialToggle
       />
       <AddTorrentsActions
         onAddTorrentsClick={() => {
@@ -134,6 +136,7 @@ const AddTorrentsByURL: FC = () => {
             destination: formData.destination,
             isBasePath: formData.isBasePath,
             isCompleted: formData.isCompleted,
+            isSequential: formData.isSequential,
             start: formData.start,
             tags,
           }).then(() => {

--- a/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
@@ -1,7 +1,9 @@
-import {createRef, MutableRefObject} from 'react';
+import {createRef, FC, MutableRefObject} from 'react';
+import {observer} from 'mobx-react';
 
 import type {TorrentProperties} from '@shared/types/Torrent';
 
+import Checkmark from '../../ui/icons/Checkmark';
 import ConfigStore from '../../stores/ConfigStore';
 import PriorityMeter from '../general/PriorityMeter';
 import TorrentActions from '../../actions/TorrentActions';
@@ -10,6 +12,27 @@ import TorrentStore from '../../stores/TorrentStore';
 import UIActions from '../../actions/UIActions';
 
 import type {ContextMenuItem} from '../../stores/UIStore';
+
+// TODO: need to create a generic component if there are more menu items like this.
+const InlineSequentialCheckbox: FC = observer(() => {
+  const {selectedTorrents} = TorrentStore;
+
+  return (
+    <label className="toggle-input checkbox" style={{display: 'inline'}}>
+      <div className="toggle-input__indicator">
+        <div
+          className="toggle-input__indicator__icon"
+          style={{
+            opacity: TorrentStore.torrents[selectedTorrents[selectedTorrents.length - 1]].isSequential
+              ? '1'
+              : undefined,
+          }}>
+          <Checkmark />
+        </div>
+      </div>
+    </label>
+  );
+});
 
 const handleTorrentDownload = (hash: TorrentProperties['hash']): void => {
   const {baseURI} = ConfigStore;
@@ -125,6 +148,20 @@ const getContextMenuItems = (torrent: TorrentProperties): Array<ContextMenuItem>
       clickHandler: () => {
         UIActions.displayModal({id: 'generate-magnet'});
       },
+    },
+    {
+      type: 'action',
+      action: 'setSequential',
+      label: TorrentContextMenuActions.setSequential.id,
+      clickHandler: () => {
+        const {selectedTorrents} = TorrentStore;
+        TorrentActions.setSequential({
+          hashes: selectedTorrents,
+          isSequential: !TorrentStore.torrents[selectedTorrents[selectedTorrents.length - 1]].isSequential,
+        });
+      },
+      dismissMenu: false,
+      labelAction: () => <InlineSequentialCheckbox />,
     },
     {
       type: 'action',

--- a/client/src/javascript/components/torrent-list/TorrentListRow.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListRow.tsx
@@ -41,7 +41,7 @@ const displayContextMenu = (hash: string, event: MouseEvent | TouchEvent) => {
         return true;
       }
 
-      return !torrentContextMenuActions.some((action) => action.id === item.action && action.visible === false);
+      return torrentContextMenuActions.some((action) => action.id === item.action && action.visible === true);
     }),
   });
 };

--- a/client/src/javascript/constants/TorrentContextMenuActions.ts
+++ b/client/src/javascript/constants/TorrentContextMenuActions.ts
@@ -29,6 +29,9 @@ const TorrentContextMenuActions = {
   generateMagnet: {
     id: 'torrents.list.context.generate.magnet',
   },
+  setSequential: {
+    id: 'torrents.list.context.sequential',
+  },
   setPriority: {
     id: 'torrents.list.context.priority',
   },

--- a/client/src/javascript/i18n/strings.compiled.json
+++ b/client/src/javascript/i18n/strings.compiled.json
@@ -2239,6 +2239,12 @@
       "value": "Remove"
     }
   ],
+  "torrents.list.context.sequential": [
+    {
+      "type": 0,
+      "value": "Sequential"
+    }
+  ],
   "torrents.list.context.set.tags": [
     {
       "type": 0,

--- a/client/src/javascript/i18n/strings.compiled.json
+++ b/client/src/javascript/i18n/strings.compiled.json
@@ -1859,6 +1859,12 @@
       "value": "Completed"
     }
   ],
+  "torrents.destination.sequential": [
+    {
+      "type": 0,
+      "value": "Sequential Download"
+    }
+  ],
   "torrents.details.actions.pause": [
     {
       "type": 0,

--- a/client/src/javascript/i18n/strings.json
+++ b/client/src/javascript/i18n/strings.json
@@ -265,6 +265,7 @@
   "torrents.create.tags.input.placeholder": "Tags in Flood. Not added to created torrent.",
   "torrents.destination.base_path": "Use as Base Path",
   "torrents.destination.completed": "Completed",
+  "torrents.destination.sequential": "Sequential Download",
   "torrents.details.actions.pause": "Pause",
   "torrents.details.actions.start": "Start",
   "torrents.details.actions.stop": "Stop",

--- a/client/src/javascript/i18n/strings.json
+++ b/client/src/javascript/i18n/strings.json
@@ -318,6 +318,7 @@
   "torrents.list.context.download": "Download",
   "torrents.list.context.priority": "Priority",
   "torrents.list.context.remove": "Remove",
+  "torrents.list.context.sequential": "Sequential",
   "torrents.list.context.set.tags": "Set Tags",
   "torrents.list.context.set.trackers": "Set Trackers",
   "torrents.list.context.start": "Start",

--- a/server/routes/api/torrents.ts
+++ b/server/routes/api/torrents.ts
@@ -20,6 +20,7 @@ import type {
   MoveTorrentsOptions,
   SetTorrentContentsPropertiesOptions,
   SetTorrentsPriorityOptions,
+  SetTorrentsSequentialOptions,
   SetTorrentsTrackersOptions,
   StartTorrentsOptions,
   StopTorrentsOptions,
@@ -120,7 +121,7 @@ router.post<unknown, unknown, AddTorrentByURLOptions>('/add-urls', async (req, r
     return;
   }
 
-  const {urls, cookies, destination, tags, isBasePath, isCompleted, start} = parsedResult.data;
+  const {urls, cookies, destination, tags, isBasePath, isCompleted, isSequential, start} = parsedResult.data;
 
   const finalDestination = await getDestination(req.services, {
     destination,
@@ -140,6 +141,7 @@ router.post<unknown, unknown, AddTorrentByURLOptions>('/add-urls', async (req, r
       tags: tags ?? [],
       isBasePath: isBasePath ?? false,
       isCompleted: isCompleted ?? false,
+      isSequential: isSequential ?? false,
       start: start ?? false,
     })
     .then((response) => {
@@ -171,7 +173,7 @@ router.post<unknown, unknown, AddTorrentByFileOptions>('/add-files', async (req,
     return;
   }
 
-  const {files, destination, tags, isBasePath, isCompleted, start} = parsedResult.data;
+  const {files, destination, tags, isBasePath, isCompleted, isSequential, start} = parsedResult.data;
 
   const finalDestination = await getDestination(req.services, {
     destination,
@@ -190,6 +192,7 @@ router.post<unknown, unknown, AddTorrentByFileOptions>('/add-files', async (req,
       tags: tags ?? [],
       isBasePath: isBasePath ?? false,
       isCompleted: isCompleted ?? false,
+      isSequential: isSequential ?? false,
       start: start ?? false,
     })
     .then((response) => {
@@ -261,6 +264,7 @@ router.post<unknown, unknown, CreateTorrentOptions>('/create', async (req, res) 
               tags: tags ?? [],
               isBasePath: true,
               isCompleted: true,
+              isSequential: false,
               start: start || false,
             })
             .catch(() => {
@@ -429,6 +433,27 @@ router.patch<unknown, unknown, SetTorrentsPriorityOptions>('/priority', (req, re
     .catch((err) => {
       callback(null, err);
     });
+});
+
+/**
+ * PATCH /api/torrents/sequential
+ * @summary Sets sequential mode of torrents.
+ * @tags Torrent
+ * @security User
+ * @param {SetTorrentsSequentialOptions} request.body.required - options - application/json
+ * @return {object} 200 - success response - application/json
+ * @return {Error} 500 - failure response - application/json
+ */
+router.patch<unknown, unknown, SetTorrentsSequentialOptions>('/sequential', (req, res) => {
+  req.services?.clientGatewayService?.setTorrentsSequential(req.body).then(
+    (response) => {
+      req.services?.torrentService.fetchTorrentList();
+      res.status(200).json(response);
+    },
+    (err) => {
+      res.status(500).json(err);
+    },
+  );
 });
 
 /**

--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -244,6 +244,11 @@ class TransmissionClientGatewayService extends ClientGatewayService {
       .then(this.processClientRequestSuccess, this.processClientRequestError);
   }
 
+  async setTorrentsSequential(): Promise<void> {
+    // Transmission maintainers rejected the feature.
+    throw new Error('Transmission does not support this feature.');
+  }
+
   async setTorrentsTags({hashes, tags}: SetTorrentsTagsOptions): Promise<void> {
     return this.clientRequestManager
       .setTorrentsProperties({ids: hashes, labels: tags})
@@ -363,6 +368,7 @@ class TransmissionClientGatewayService extends ClientGatewayService {
                 upTotal: torrent.uploadedEver,
                 eta: torrent.eta,
                 isPrivate: torrent.isPrivate,
+                isSequential: false,
                 message: torrent.errorString,
                 peersConnected: torrent.peersGettingFromUs,
                 peersTotal: torrent.peersGettingFromUs,

--- a/server/services/feedService.ts
+++ b/server/services/feedService.ts
@@ -256,6 +256,7 @@ class FeedService extends BaseService {
                   start,
                   isBasePath: false,
                   isCompleted: false,
+                  isSequential: false,
                 })
                 .then(() => {
                   this.db.update({_id: feedID}, {$inc: {count: 1}}, {upsert: true});

--- a/server/services/interfaces/clientGatewayService.ts
+++ b/server/services/interfaces/clientGatewayService.ts
@@ -9,6 +9,7 @@ import type {
   MoveTorrentsOptions,
   SetTorrentContentsPropertiesOptions,
   SetTorrentsPriorityOptions,
+  SetTorrentsSequentialOptions,
   SetTorrentsTrackersOptions,
   StartTorrentsOptions,
   StopTorrentsOptions,
@@ -106,6 +107,14 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @return {Promise<void>} - Rejects with error.
    */
   abstract setTorrentsPriority(options: SetTorrentsPriorityOptions): Promise<void>;
+
+  /**
+   * Sets sequential mode of torrents
+   *
+   * @param {SetTorrentsSequentialOptions} options - An object of options...
+   * @return {Promise<void>} - Rejects with error.
+   */
+  abstract setTorrentsSequential(options: SetTorrentsSequentialOptions): Promise<void>;
 
   /**
    * Sets tags of torrents

--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -193,6 +193,11 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
     }
   }
 
+  async setTorrentsSequential(): Promise<void> {
+    // TODO: not implemented
+    throw new Error();
+  }
+
   async setTorrentsTags({hashes, tags}: SetTorrentsTagsOptions): Promise<void> {
     return this.clientRequestManager.torrentsRemoveTags(hashes).then(() => {
       this.clientRequestManager
@@ -294,6 +299,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
                 eta: info.eta >= 8640000 ? -1 : info.eta,
                 hash: info.hash,
                 isPrivate,
+                isSequential: false, // TODO: not implemented
                 message: '', // in tracker method
                 name: info.name,
                 peersConnected: info.num_leechs,

--- a/server/services/qBittorrent/clientRequestManager.ts
+++ b/server/services/qBittorrent/clientRequestManager.ts
@@ -299,6 +299,21 @@ class ClientRequestManager {
     }
   }
 
+  async torrentsToggleSequentialDownload(hashes: Array<string>): Promise<void> {
+    if (hashes.length > 0) {
+      return axios
+        .get(`${this.apiBase}/torrents/toggleSequentialDownload`, {
+          params: {
+            hashes: hashes.join('|'),
+          },
+          headers: {Cookie: await this.authCookie},
+        })
+        .then(() => {
+          // returns nothing
+        });
+    }
+  }
+
   async torrentsFilePrio(hash: string, ids: Array<number>, priority: QBittorrentTorrentContentPriority) {
     return axios
       .get(`${this.apiBase}/torrents/filePrio?hash=${hash}&id=${ids.join('|')}&priority=${priority}`, {

--- a/server/services/rTorrent/clientGatewayService.ts
+++ b/server/services/rTorrent/clientGatewayService.ts
@@ -63,6 +63,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
     tags,
     isBasePath,
     isCompleted,
+    isSequential,
     start,
   }: Required<AddTorrentByFileOptions>): Promise<void> {
     const torrentPaths = await Promise.all(
@@ -81,6 +82,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
         tags,
         isBasePath,
         isCompleted,
+        isSequential,
         start,
       });
     }
@@ -433,6 +435,11 @@ class RTorrentClientGatewayService extends ClientGatewayService {
     );
   }
 
+  async setTorrentsSequential(): Promise<void> {
+    // TODO: not implemented
+    throw new Error();
+  }
+
   async setTorrentsTags({hashes, tags}: SetTorrentsTagsOptions): Promise<void> {
     const methodCalls = hashes.reduce((accumulator: MultiMethodCalls, hash) => {
       accumulator.push({
@@ -601,6 +608,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
               processedResponses.map(async (response) => {
                 const torrentProperties: TorrentProperties = {
                   ...response,
+                  isSequential: false, // TODO: not implemented
                   status: getTorrentStatusFromProperties(response),
                   percentComplete: getTorrentPercentCompleteFromProperties(response),
                   eta: getTorrentETAFromProperties(response),

--- a/server/services/rTorrent/clientGatewayService.ts
+++ b/server/services/rTorrent/clientGatewayService.ts
@@ -629,10 +629,31 @@ class RTorrentClientGatewayService extends ClientGatewayService {
             ...(await Promise.all(
               processedResponses.map(async (response) => {
                 const torrentProperties: TorrentProperties = {
-                  ...response,
-                  status: getTorrentStatusFromProperties(response),
-                  percentComplete: getTorrentPercentCompleteFromProperties(response),
+                  bytesDone: response.bytesDone,
+                  dateAdded: response.dateAdded,
+                  dateCreated: response.dateCreated,
+                  directory: response.directory,
+                  downRate: response.downRate,
+                  downTotal: response.downTotal,
                   eta: getTorrentETAFromProperties(response),
+                  hash: response.hash,
+                  isPrivate: response.isPrivate,
+                  isSequential: response.isSequential,
+                  message: response.message,
+                  name: response.name,
+                  peersConnected: response.peersConnected,
+                  peersTotal: response.peersTotal,
+                  percentComplete: getTorrentPercentCompleteFromProperties(response),
+                  priority: response.priority,
+                  ratio: response.ratio,
+                  seedsConnected: response.seedsConnected,
+                  seedsTotal: response.seedsTotal,
+                  sizeBytes: response.sizeBytes,
+                  status: getTorrentStatusFromProperties(response),
+                  tags: response.tags,
+                  trackerURIs: response.trackerURIs,
+                  upRate: response.upRate,
+                  upTotal: response.upTotal,
                 };
 
                 this.emit('PROCESS_TORRENT', torrentProperties);

--- a/server/services/rTorrent/constants/methodCallConfigs/torrentList.ts
+++ b/server/services/rTorrent/constants/methodCallConfigs/torrentList.ts
@@ -30,6 +30,10 @@ const torrentListMethodCallConfigs = {
     methodCall: 'd.is_private=',
     transformValue: booleanTransformer,
   },
+  isSequential: {
+    methodCall: 'd.down.sequential=',
+    transformValue: booleanTransformer,
+  },
   isOpen: {
     methodCall: 'd.is_open=',
     transformValue: booleanTransformer,

--- a/shared/constants/defaultFloodSettings.ts
+++ b/shared/constants/defaultFloodSettings.ts
@@ -59,6 +59,7 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
     {id: 'torrentDetails', visible: true},
     {id: 'torrentDownload', visible: true},
     {id: 'generateMagnet', visible: false},
+    {id: 'setSequential', visible: false},
     {id: 'setPriority', visible: false},
   ],
   torrentListViewSize: 'condensed',

--- a/shared/schema/api/torrents.ts
+++ b/shared/schema/api/torrents.ts
@@ -21,6 +21,8 @@ export const addTorrentByURLSchema = object({
   isBasePath: boolean().optional(),
   // Whether destination contains completed contents [default: false]
   isCompleted: boolean().optional(),
+  // Whether contents of a torrent should be downloaded sequentially [default: false]
+  isSequential: boolean().optional(),
   // Whether to start torrent [default: false]
   start: boolean().optional(),
 });
@@ -39,6 +41,8 @@ export const addTorrentByFileSchema = object({
   isBasePath: boolean().optional(),
   // Whether destination contains completed contents [default: false]
   isCompleted: boolean().optional(),
+  // Whether contents of a torrent should be downloaded sequentially [default: false]
+  isSequential: boolean().optional(),
   // Whether to start torrent [default: false]
   start: boolean().optional(),
 });

--- a/shared/types/Torrent.ts
+++ b/shared/types/Torrent.ts
@@ -27,6 +27,8 @@ export interface TorrentProperties {
   eta: number;
   hash: string;
   isPrivate: boolean;
+  // If sequential download is enabled
+  isSequential: boolean;
   message: string;
   name: string;
   peersConnected: number;

--- a/shared/types/api/torrents.ts
+++ b/shared/types/api/torrents.ts
@@ -71,6 +71,14 @@ export interface SetTorrentsPriorityOptions {
   priority: TorrentPriority;
 }
 
+// PATCH /api/torrents/sequential
+export interface SetTorrentsSequentialOptions {
+  // An array of string representing hashes of torrents to operate on
+  hashes: Array<TorrentProperties['hash']>;
+  // If sequential download is enabled
+  isSequential: boolean;
+}
+
 // PATCH /api/torrents/trackers
 export interface SetTorrentsTrackersOptions {
   // An array of string representing hashes of torrents to operate on


### PR DESCRIPTION
### Work in progress

Client:
- rTorrent: requires "d.down.sequential(.set)" commands, see https://github.com/jesec/rtorrent/commit/bd904e366367cb9cbe007381089eea066253c9e9
- qBittorrent: supported
- Transmission: rejected, see [https://trac.transmissionbt.com/ticket/452](https://trac.transmissionbt.com/ticket/452)

Drawbacks:
- https://wiki.vuze.com/w/Sequential_downloading_is_bad

Benefits:
1. Sequential downloading helps with I/O performance and lowers resource consumption and cost of hardware. It enables predictable I/O patterns and efficient caching. My hard disk is really noisy while downloading a torrent. But with sequential downloading, it does not make a sound. Speed is much better as well. Sequential I/O patterns also eliminate disk fragmentation problem that damages performance/lifespan of hard disks in long-term, which is a headache for long seeders.
1. "It is bad for swarms." That's correct for unhealthy swarms. However, for private torrent users, in most cases, the seeder/leecher relationship is "many seeder, single/little leecher". Plus, with the incentives/punishments of tracker sites, there is little to no risk of "draining". As such, it makes more sense to protect hardware of everyone in the swarm. Predictable I/O patterns also allow seeders to seed many torrents more efficiently: if leechers use sequential download, the read patterns become predictably sequential, which allows better I/O performance and reduces the failure rate of hard disks. 
1. For seedbox users: seedboxes are virtual machines. That means many users share the same physical machine. Random chunk downloading is extremely taxing on disks. As a result, usually the speeds are limited by I/O more than bandwidth. If the swarm pattern is usually "many seeder, single leecher", sequential downloading can help a lot. 
1. Widely known "self" benefits: stream early, stream while downloading, organize episodes quick and unpack some files before finish, etc.

