### PR TITLE
feature: support initial seeding (aka superseeding)

### DIFF
--- a/client/src/javascript/actions/TorrentActions.ts
+++ b/client/src/javascript/actions/TorrentActions.ts
@@ -12,6 +12,7 @@ import type {
   DeleteTorrentsOptions,
   MoveTorrentsOptions,
   SetTorrentContentsPropertiesOptions,
+  SetTorrentsInitialSeedingOptions,
   SetTorrentsPriorityOptions,
   SetTorrentsSequentialOptions,
   SetTorrentsTrackersOptions,
@@ -193,6 +194,19 @@ const TorrentActions = {
     }
     return undefined;
   },
+
+  setInitialSeeding: (options: SetTorrentsInitialSeedingOptions) =>
+    axios
+      .patch(`${baseURI}api/torrents/initial-seeding`, options)
+      .then((json) => json.data)
+      .then(
+        () => {
+          // do nothing.
+        },
+        () => {
+          // do nothing.
+        },
+      ),
 
   setPriority: (options: SetTorrentsPriorityOptions) =>
     axios

--- a/client/src/javascript/constants/TorrentContextMenuActions.ts
+++ b/client/src/javascript/constants/TorrentContextMenuActions.ts
@@ -29,6 +29,9 @@ const TorrentContextMenuActions = {
   generateMagnet: {
     id: 'torrents.list.context.generate.magnet',
   },
+  setInitialSeeding: {
+    id: 'torrents.list.context.initial.seeding',
+  },
   setSequential: {
     id: 'torrents.list.context.sequential',
   },

--- a/client/src/javascript/i18n/strings.compiled.json
+++ b/client/src/javascript/i18n/strings.compiled.json
@@ -2221,6 +2221,12 @@
       "value": "Generate Magnet Link"
     }
   ],
+  "torrents.list.context.initial.seeding": [
+    {
+      "type": 0,
+      "value": "Initial Seeding"
+    }
+  ],
   "torrents.list.context.move": [
     {
       "type": 0,

--- a/client/src/javascript/i18n/strings.json
+++ b/client/src/javascript/i18n/strings.json
@@ -317,6 +317,7 @@
   "torrents.list.context.move": "Set Torrent Location",
   "torrents.list.context.pause": "Pause",
   "torrents.list.context.download": "Download",
+  "torrents.list.context.initial.seeding": "Initial Seeding",
   "torrents.list.context.priority": "Priority",
   "torrents.list.context.remove": "Remove",
   "torrents.list.context.sequential": "Sequential",

--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -220,6 +220,10 @@ class TransmissionClientGatewayService extends ClientGatewayService {
       .then(this.processClientRequestSuccess, this.processClientRequestError);
   }
 
+  async setTorrentsInitialSeeding(): Promise<void> {
+    throw new Error('Transmission does not support this feature.');
+  }
+
   async setTorrentsPriority({hashes, priority}: SetTorrentsPriorityOptions): Promise<void> {
     let transmissionPriority = TransmissionPriority.TR_PRI_NORMAL;
 
@@ -368,6 +372,7 @@ class TransmissionClientGatewayService extends ClientGatewayService {
                 upTotal: torrent.uploadedEver,
                 eta: torrent.eta,
                 isPrivate: torrent.isPrivate,
+                isInitialSeeding: false,
                 isSequential: false,
                 message: torrent.errorString,
                 peersConnected: torrent.peersGettingFromUs,

--- a/server/services/feedService.ts
+++ b/server/services/feedService.ts
@@ -257,6 +257,7 @@ class FeedService extends BaseService {
                   isBasePath: false,
                   isCompleted: false,
                   isSequential: false,
+                  isInitialSeeding: false,
                 })
                 .then(() => {
                   this.db.update({_id: feedID}, {$inc: {count: 1}}, {upsert: true});

--- a/server/services/interfaces/clientGatewayService.ts
+++ b/server/services/interfaces/clientGatewayService.ts
@@ -8,6 +8,7 @@ import type {
   DeleteTorrentsOptions,
   MoveTorrentsOptions,
   SetTorrentContentsPropertiesOptions,
+  SetTorrentsInitialSeedingOptions,
   SetTorrentsPriorityOptions,
   SetTorrentsSequentialOptions,
   SetTorrentsTrackersOptions,
@@ -99,6 +100,14 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @return {Promise<void>} - Rejects with error.
    */
   abstract removeTorrents(options: DeleteTorrentsOptions): Promise<void>;
+
+  /**
+   * Sets initial seeding mode of torrents
+   *
+   * @param {SetTorrentsInitialSeedingOptions} options - An object of options...
+   * @return {Promise<void>} - Rejects with error.
+   */
+  abstract setTorrentsInitialSeeding(options: SetTorrentsInitialSeedingOptions): Promise<void>;
 
   /**
    * Sets priority of torrents

--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -8,6 +8,7 @@ import type {
   DeleteTorrentsOptions,
   MoveTorrentsOptions,
   SetTorrentContentsPropertiesOptions,
+  SetTorrentsInitialSeedingOptions,
   SetTorrentsPriorityOptions,
   SetTorrentsSequentialOptions,
   SetTorrentsTrackersOptions,
@@ -48,7 +49,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
     isSequential,
     start,
   }: Required<AddTorrentByFileOptions>): Promise<void> {
-    // TODO: isCompleted not implemented
+    // TODO: isCompleted and isInitialSeeding not implemented
 
     const fileBuffers = files.map((file) => {
       return Buffer.from(file, 'base64');
@@ -74,7 +75,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
     isSequential,
     start,
   }: Required<AddTorrentByURLOptions>): Promise<void> {
-    // TODO: isCompleted not implemented
+    // TODO: isCompleted and isInitialSeeding not implemented
 
     return this.clientRequestManager
       .torrentsAddURLs(urls, {
@@ -181,6 +182,12 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
   async removeTorrents({hashes, deleteData}: DeleteTorrentsOptions): Promise<void> {
     return this.clientRequestManager
       .torrentsDelete(hashes, deleteData || false)
+      .then(this.processClientRequestSuccess, this.processClientRequestError);
+  }
+
+  async setTorrentsInitialSeeding({hashes, isInitialSeeding}: SetTorrentsInitialSeedingOptions): Promise<void> {
+    return this.clientRequestManager
+      .torrentsSetSuperSeeding(hashes, isInitialSeeding)
       .then(this.processClientRequestSuccess, this.processClientRequestError);
   }
 
@@ -318,6 +325,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
                 eta: info.eta >= 8640000 ? -1 : info.eta,
                 hash: info.hash,
                 isPrivate,
+                isInitialSeeding: info.super_seeding,
                 isSequential: info.seq_dl,
                 message: '', // in tracker method
                 name: info.name,

--- a/server/services/qBittorrent/clientRequestManager.ts
+++ b/server/services/qBittorrent/clientRequestManager.ts
@@ -299,6 +299,22 @@ class ClientRequestManager {
     }
   }
 
+  async torrentsSetSuperSeeding(hashes: Array<string>, value: boolean): Promise<void> {
+    if (hashes.length > 0) {
+      return axios
+        .get(`${this.apiBase}/torrents/setSuperSeeding`, {
+          params: {
+            hashes: hashes.join('|'),
+            value: value ? 'true' : 'false',
+          },
+          headers: {Cookie: await this.authCookie},
+        })
+        .then(() => {
+          // returns nothing
+        });
+    }
+  }
+
   async torrentsToggleSequentialDownload(hashes: Array<string>): Promise<void> {
     if (hashes.length > 0) {
       return axios

--- a/server/services/rTorrent/constants/methodCallConfigs/torrentList.ts
+++ b/server/services/rTorrent/constants/methodCallConfigs/torrentList.ts
@@ -30,6 +30,12 @@ const torrentListMethodCallConfigs = {
     methodCall: 'd.is_private=',
     transformValue: booleanTransformer,
   },
+  isInitialSeeding: {
+    methodCall: 'd.connection_seed=',
+    transformValue: (value: unknown): boolean => {
+      return value === 'initial_seed';
+    },
+  },
   isSequential: {
     methodCall: 'd.down.sequential=',
     transformValue: booleanTransformer,

--- a/shared/constants/defaultFloodSettings.ts
+++ b/shared/constants/defaultFloodSettings.ts
@@ -59,6 +59,7 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
     {id: 'torrentDetails', visible: true},
     {id: 'torrentDownload', visible: true},
     {id: 'generateMagnet', visible: false},
+    {id: 'setInitialSeeding', visible: false},
     {id: 'setSequential', visible: false},
     {id: 'setPriority', visible: false},
   ],

--- a/shared/schema/api/torrents.ts
+++ b/shared/schema/api/torrents.ts
@@ -23,6 +23,8 @@ export const addTorrentByURLSchema = object({
   isCompleted: boolean().optional(),
   // Whether contents of a torrent should be downloaded sequentially [default: false]
   isSequential: boolean().optional(),
+  // Whether to use initial seeding mode [default: false]
+  isInitialSeeding: boolean().optional(),
   // Whether to start torrent [default: false]
   start: boolean().optional(),
 });
@@ -43,6 +45,8 @@ export const addTorrentByFileSchema = object({
   isCompleted: boolean().optional(),
   // Whether contents of a torrent should be downloaded sequentially [default: false]
   isSequential: boolean().optional(),
+  // Whether to use initial seeding mode [default: false]
+  isInitialSeeding: boolean().optional(),
   // Whether to start torrent [default: false]
   start: boolean().optional(),
 });

--- a/shared/types/Torrent.ts
+++ b/shared/types/Torrent.ts
@@ -27,6 +27,8 @@ export interface TorrentProperties {
   eta: number;
   hash: string;
   isPrivate: boolean;
+  // If initial seeding mode (aka super seeding) is enabled
+  isInitialSeeding: boolean;
   // If sequential download is enabled
   isSequential: boolean;
   message: string;

--- a/shared/types/api/torrents.ts
+++ b/shared/types/api/torrents.ts
@@ -17,6 +17,8 @@ export interface CreateTorrentOptions {
   infoSource?: string;
   // Whether the torrent is private
   isPrivate: boolean;
+  // Whether to use initial seeding mode
+  isInitialSeeding?: boolean;
   // Whether to start torrent
   start?: boolean;
   // Tags, not added to torrent file
@@ -61,6 +63,14 @@ export interface StartTorrentsOptions {
 export interface StopTorrentsOptions {
   // An array of string representing hashes of torrents to be stopped
   hashes: Array<TorrentProperties['hash']>;
+}
+
+// PATCH /api/torrents/initial-seeding
+export interface SetTorrentsInitialSeedingOptions {
+  // An array of string representing hashes of torrents to operate on
+  hashes: Array<TorrentProperties['hash']>;
+  // If initial seeding mode (aka super seeding) is enabled
+  isInitialSeeding: boolean;
 }
 
 // PATCH /api/torrents/priority


### PR DESCRIPTION
https://www.bittorrent.org/beps/bep_0016.html

Client:
- rTorrent: ~supported, https://github.com/rakshasa/rtorrent/wiki/Using-initial-seeding~ not exposed to RPC interface, requires https://github.com/jesec/rtorrent/commit/657089d438f917714c2386c28ce9d01a6e6a2737. 
- qBittorrent: supported, https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-super-seeding
- Transmission: not supported, see https://trac.transmissionbt.com/ticket/1691