### PR TITLE
Clarify that Flood's torrent upload is also reliant on the "same path rule"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Run the installation command again.
   - Windows users can use [Cygwin](https://www.cygwin.com/) to install rTorrent.
   - [Compile](https://github.com/rakshasa/rtorrent/wiki/Installing): XMLRPC support flag (`--with-xmlrpc-c`) is required during compilation.
   - Certain features (sequential download, initial seeding, etc.) are not available in vanilla rTorrent.
+  - rTorrent needs to have read access to files of temporary directory of Flood (`<rundir>/temp`) as Flood adds torrents to rTorrent by local file path ([96c754dd](https://github.com/jesec/flood/commit/96c754ddeb614b45a565e8307c9985ee85bcb7fa)). This is because rTorrent uses a rather antique XML-RPC interface, which usually has certain limitations (size of body) and is unreliable in handling large binary objects ([Flood-UI/flood#164](https://github.com/Flood-UI/flood/issues/164), [Flood-UI/flood#741](https://github.com/Flood-UI/flood/issues/741), [Flood-UI/flood#773](https://github.com/Flood-UI/flood/issues/773)). See [#86](https://github.com/jesec/flood/discussions/86).
 - Ask for help in the [Flood Discord server](https://discord.gg/Z7yR5Uf).
 
 ### Docker


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I was trying to get Flood running since 1 week and everything was working except the .torrent upload. It wasn't really clear in the documentation that the temp folder of Flood needed to be accessible to rTorrent in order for it to add torrents (I thought torrent data was sent with the request entirely). So I modified the Readme to be totally clear on that.
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
