### PR TITLE
Add role attribute to clickable elements

### DIFF
--- a/client/src/javascript/components/general/Tooltip.tsx
+++ b/client/src/javascript/components/general/Tooltip.tsx
@@ -402,6 +402,8 @@ class Tooltip extends Component<TooltipProps, TooltipStates> {
     return (
       <div
         className={wrapperClassName}
+        role="button"
+        tabIndex={0}
         onClick={onClick}
         onMouseEnter={() => this.handleMouseEnter()}
         onMouseLeave={() => this.handleMouseLeave()}

--- a/client/src/javascript/components/sidebar/SidebarFilter.tsx
+++ b/client/src/javascript/components/sidebar/SidebarFilter.tsx
@@ -38,7 +38,7 @@ const SidebarFilter: FC<SidebarFilterProps> = (props: SidebarFilterProps) => {
   }
 
   return (
-    <li className={classNames} onClick={() => handleClick(slug)}>
+    <li className={classNames} onClick={() => handleClick(slug)} role="menuitem">
       {icon}
       {name}
       <Badge>{count}</Badge>


### PR DESCRIPTION
Add support for vimium keyboard navigation and screen readers

  * Add menuitem role to SidebarFilter li
  * Add button role to Tooltip div

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds `role="menuitem"` to clickable `li` elements in SidebarFilter and `role="button" tabIndex={0}` to `div` elements in Tooltip

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/Flood-UI/flood/issues/885

<!--- Optional -->

## Screenshots
![tooltip](https://user-images.githubusercontent.com/1317690/95891410-e5861a00-0d39-11eb-992c-a92aeb7651f4.png)
![sidebar](https://user-images.githubusercontent.com/1317690/95891602-2716c500-0d3a-11eb-8cb3-7758697bc0f0.png)
<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
