### PR TITLE
rTorrent: use JSON-RPC when available

### DIFF
--- a/server/services/rTorrent/clientRequestManager.ts
+++ b/server/services/rTorrent/clientRequestManager.ts
@@ -2,8 +2,8 @@ import type {NetConnectOpts} from 'net';
 
 import type {RTorrentConnectionSettings} from '@shared/schema/ClientConnectionSettings';
 
+import {methodCallJSON, methodCallXML} from './util/scgiUtil';
 import {sanitizePath} from '../../util/fileUtil';
-import scgiUtil from './util/scgiUtil';
 
 import type {MultiMethodCalls} from './util/rTorrentMethodCallUtil';
 
@@ -11,6 +11,7 @@ type MethodCallParameters = Array<string | Buffer | MultiMethodCalls>;
 
 class ClientRequestManager {
   connectionSettings: RTorrentConnectionSettings;
+  isJSONCapable = false;
   isRequestPending = false;
   lastResponseTimestamp = 0;
   pendingRequests: Array<{
@@ -70,7 +71,11 @@ class ClientRequestManager {
             port: this.connectionSettings.port,
           };
 
-    return scgiUtil.methodCall(connectionOptions, methodName, parameters).then(
+    const methodCall = this.isJSONCapable
+      ? methodCallJSON(connectionOptions, methodName, parameters)
+      : methodCallXML(connectionOptions, methodName, parameters);
+
+    return methodCall.then(
       (response) => {
         this.handleRequestEnd();
         return response;


### PR DESCRIPTION
Preliminary tests: (compared to XMLRPC)

2x performance, 15% lower total CPU time in rTorrent process, 33% lower total CPU time in Node.js process. Note that there are 28000+ entries, so it is natural to take seconds to complete the request. Additionally, current implementation on the rTorrent side uses nlohmann's `JSON for Modern C++`, which is the easiest to use but it is not one of the most "High Performance" JSON library. Some JSON libraries feature up to [8x performance](https://github.com/miloyip/nativejson-benchmark#stringify-time) over nlohmann/json. 

![image](https://user-images.githubusercontent.com/11585141/109640113-00431900-7b8b-11eb-89b8-f6968246bb9a.png)
