### PR TITLE
feat: api authentication support Authorization header

### DIFF
--- a/server/config/passport.ts
+++ b/server/config/passport.ts
@@ -1,4 +1,4 @@
-import {Strategy} from 'passport-jwt';
+import {Strategy,ExtractJwt} from 'passport-jwt';
 
 import type {PassportStatic} from 'passport';
 import type {Request} from 'express';
@@ -11,7 +11,7 @@ import Users from '../models/Users';
 // Setup work and export for the JWT passport strategy.
 export default (passport: PassportStatic) => {
   const options = {
-    jwtFromRequest: (req: Request) => req?.cookies?.jwt,
+    jwtFromRequest: (req: Request) => req?.cookies?.jwt || ExtractJwt.fromAuthHeaderAsBearerToken()(req),
     secretOrKey: config.secret,
   };
 

--- a/server/config/passport.ts
+++ b/server/config/passport.ts
@@ -1,4 +1,4 @@
-import {Strategy,ExtractJwt} from 'passport-jwt';
+import {Strategy, ExtractJwt} from 'passport-jwt';
 
 import type {PassportStatic} from 'passport';
 import type {Request} from 'express';

--- a/server/routes/api/auth.ts
+++ b/server/routes/api/auth.ts
@@ -45,12 +45,14 @@ const sendAuthenticationResponse = (
 ): Response => {
   const {username, level} = credentials;
 
-  res.cookie('jwt', getAuthToken(username), getCookieOptions());
+  const token = getAuthToken(username);
+  res.cookie('jwt', token, getCookieOptions());
 
   const response: AuthAuthenticationResponse = {
     success: true,
     username,
     level,
+    token,
   };
 
   return res.json(response);

--- a/shared/schema/api/auth.ts
+++ b/shared/schema/api/auth.ts
@@ -19,6 +19,7 @@ export interface AuthAuthenticationResponse {
   success: boolean;
   username: string;
   level: AccessLevel;
+  token: string;
 }
 
 // POST /api/auth/register


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[Browsers block frontend JavaScript code from accessing the `Set Cookie` header, as required by the Fetch spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie), so the current cookie method is not friendly for web fetch.

This PR allows API to use the Bearer header for authentication. 

If you are interested in this PR, I can add unit tests.

## Test plan

1. call `/auth/authenticate` returns `{ token }`
2. call `/client/connection-test` with `Authorization: Bearer <token>` header
3. response success

- [x] follow the test plan

## Types of changes

- [x] New feature (non-breaking change which adds functionality - semver MINOR)

