### PR TITLE
server: qBittorrent: Update the status filter behavior

### DIFF
--- a/client/src/javascript/components/sidebar/StatusFilters.tsx
+++ b/client/src/javascript/components/sidebar/StatusFilters.tsx
@@ -29,6 +29,11 @@ const StatusFilters: FC = observer(() => {
       icon: <DownloadSmall />,
     },
     {
+      label: i18n._('filter.status.paused'),
+      slug: 'paused',
+      icon: <UploadSmall />,
+    },
+    {
       label: i18n._('filter.status.seeding'),
       slug: 'seeding',
       icon: <UploadSmall />,

--- a/client/src/javascript/i18n/strings/en.json
+++ b/client/src/javascript/i18n/strings/en.json
@@ -131,6 +131,7 @@
   "filter.status.checking": "Checking",
   "filter.status.completed": "Complete",
   "filter.status.downloading": "Downloading",
+  "filter.status.paused": "Paused",
   "filter.status.error": "Error",
   "filter.status.inactive": "Inactive",
   "filter.status.seeding": "Seeding",

--- a/client/src/javascript/util/torrentStatusClasses.ts
+++ b/client/src/javascript/util/torrentStatusClasses.ts
@@ -10,6 +10,7 @@ function torrentStatusClasses(
     'torrent--has-error': status.includes('error'),
     'torrent--is-stopped': status.includes('stopped'),
     'torrent--is-downloading': status.includes('downloading'),
+    'torrent--is-paused':  status.includes('paused'),
     'torrent--is-downloading--actively': downRate > 0,
     'torrent--is-uploading--actively': upRate > 0,
     'torrent--is-seeding': status.includes('seeding'),

--- a/server/services/qBittorrent/util/torrentPropertiesUtil.ts
+++ b/server/services/qBittorrent/util/torrentPropertiesUtil.ts
@@ -68,6 +68,7 @@ export const getTorrentStatusFromState = (state: QBittorrentTorrentState): Torre
       statuses.push('downloading');
       break;
     case 'pausedDL':
+      statuses.push('paused');
       statuses.push('inactive');
       statuses.push('stopped');
       break;

--- a/shared/constants/torrentStatusMap.ts
+++ b/shared/constants/torrentStatusMap.ts
@@ -1,6 +1,7 @@
 const torrentStatusMap = [
   'checking',
   'seeding',
+  'paused',
   'complete',
   'downloading',
   'stopped',


### PR DESCRIPTION
server: qBittorrent: Update the status filter behavior so that UX is in sync with qB GUI/WebUI.

## Description

Mainly appends 'pausedDL' torrents to 'Downloading' status.

I understand rtorrent/rutorrent may have the design of classifying torrent status, and I'm not sure if you want to unify the logic for the current three backends, but this PR would be more natural logically for qBittorrent users.

Adjustment based on:
https://github.com/CzBiX/qb-web/blob/809d5bab4b5b4566cd3d74eb6e5df243fb4a17c1/src/utils.ts#L4


## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
