### PR TITLE
Larger torrent infos modal

### DIFF
--- a/client/src/sass/components/_modals.scss
+++ b/client/src/sass/components/_modals.scss
@@ -365,7 +365,7 @@ $modal--tabs--padding--vertical--left: $modal--padding--horizontal;
 
   &--size {
     &-large {
-      width: 700px;
+      width: 850px;
 
       &.modal {
         &__content {


### PR DESCRIPTION
## Description

Regarding the width of today's screens, it appears more comfortable to have a slightly larger torrent info modal.

I think it would be a nice to have UX improvement.

## Related Issue

None.

## Screenshots

From :

https://i.imgur.com/WehobrX.png

To :

https://i.imgur.com/8DR2U5x.png

## Types of changes

UX improvement.