### PR TITLE
client: add CMD-A, CTRL-A to select all torrents

### DIFF
--- a/client/src/javascript/actions/UIActions.ts
+++ b/client/src/javascript/actions/UIActions.ts
@@ -33,6 +33,10 @@ const UIActions = {
     TorrentStore.setSelectedTorrents(data);
   },
 
+  selectAllTorrents: () => {
+    TorrentStore.selectAllTorrents();
+  },
+
   setTorrentStatusFilter: (status: TorrentStatus) => {
     TorrentFilterStore.setStatusFilter(status);
   },

--- a/client/src/javascript/components/torrent-list/TorrentList.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentList.tsx
@@ -1,7 +1,8 @@
-import {FC, ReactNode, useEffect, useRef} from 'react';
+import {FC, KeyboardEvent, ReactNode, useEffect, useRef} from 'react';
 import {observer} from 'mobx-react';
 import {reaction} from 'mobx';
 import {Trans} from '@lingui/react';
+import {useEvent} from 'react-use';
 
 import type {FixedSizeList, ListChildComponentProps} from 'react-window';
 
@@ -12,6 +13,7 @@ import SettingActions from '@client/actions/SettingActions';
 import SettingStore from '@client/stores/SettingStore';
 import TorrentFilterStore from '@client/stores/TorrentFilterStore';
 import TorrentStore from '@client/stores/TorrentStore';
+import UIActions from '@client/actions/UIActions';
 
 import SortDirections from '@client/constants/SortDirections';
 
@@ -46,6 +48,24 @@ const TorrentList: FC = observer(() => {
 
     return dispose;
   }, []);
+
+  useEvent('keydown', (e: KeyboardEvent) => {
+    const {ctrlKey, key, metaKey, repeat, target} = e;
+
+    const tagName = (target as HTMLElement)?.tagName.toUpperCase();
+    if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+      return;
+    }
+
+    if (repeat) {
+      return;
+    }
+
+    if ((metaKey || ctrlKey) && key === 'a') {
+      e.preventDefault();
+      UIActions.selectAllTorrents();
+    }
+  });
 
   const torrents = TorrentStore.filteredTorrents;
   const {torrentListViewSize = 'condensed'} = SettingStore.floodSettings;

--- a/client/src/javascript/stores/TorrentStore.ts
+++ b/client/src/javascript/stores/TorrentStore.ts
@@ -65,6 +65,10 @@ class TorrentStore {
     });
   }
 
+  selectAllTorrents() {
+    this.selectedTorrents = this.filteredTorrents.map((v) => v.hash);
+  }
+
   handleTorrentListDiffChange(torrentListDiffs: Operation[]) {
     applyPatch(this.torrents, torrentListDiffs);
   }


### PR DESCRIPTION
## Description

After the user selected a torrent, user can use `CMD-A` or `CTRL-A` to select all torrents. Click one torrent to deselect all. Very useful for bulk editing large collection of torrents.

For https://github.com/jesec/flood/discussions/122#discussioncomment-480117

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
