### PR TITLE
feat: add tini to container images

### DIFF
--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -12,7 +12,8 @@ RUN npm i -g "${PACKAGE}"@"${VERSION}" &&\
 
 # Install runtime dependencies
 RUN apk --no-cache add \
-    mediainfo
+    mediainfo \
+    tini
 
 # Create "download" user
 RUN adduser -h /home/download -s /sbin/nologin --disabled-password download
@@ -24,4 +25,5 @@ USER download
 EXPOSE 3000
 
 # Flood
-ENTRYPOINT ["flood", "--host=0.0.0.0"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["flood", "--host=0.0.0.0"]

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -9,4 +9,5 @@ FROM jesec/flood:$FLOOD_VERSION as flood
 COPY --from=rtorrent / /
 
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["flood", "--host=0.0.0.0", "--rtorrent"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["flood", "--host=0.0.0.0", "--rtorrent"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Small change here. I created an `ENTRYPOINT` with [tini](https://github.com/krallin/tini) and updated the `CMD` in the `Dockerfile`s. tini is already included in the `Docker` CRI, however some people (like me) use a different CRI like `containerd` or `cri-o` where we don't have access to an `--init` flag. 

`tini` also has other benefits as described in this [Github issue](https://github.com/krallin/tini/issues/8#issuecomment-146135930).

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

Container image change
