### PR TITLE
fix: flood entrypoint in container images

### DIFF
--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -25,5 +25,5 @@ USER download
 EXPOSE 3000
 
 # Flood
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["flood", "--host=0.0.0.0"]
+ENTRYPOINT ["/sbin/tini", "--", "flood"]
+CMD ["--host=0.0.0.0"]

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -25,5 +25,4 @@ USER download
 EXPOSE 3000
 
 # Flood
-ENTRYPOINT ["/sbin/tini", "--", "flood"]
-CMD ["--host=0.0.0.0"]
+ENTRYPOINT ["/sbin/tini", "--", "flood", "--host=0.0.0.0"]

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -9,5 +9,4 @@ FROM jesec/flood:$FLOOD_VERSION as flood
 COPY --from=rtorrent / /
 
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["/sbin/tini", "--", "flood"]
-CMD ["--host=0.0.0.0", "--rtorrent"]
+ENTRYPOINT ["/sbin/tini", "--", "flood", "--host=0.0.0.0", "--rtorrent"]

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -9,5 +9,5 @@ FROM jesec/flood:$FLOOD_VERSION as flood
 COPY --from=rtorrent / /
 
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["flood", "--host=0.0.0.0", "--rtorrent"]
+ENTRYPOINT ["/sbin/tini", "--", "flood"]
+CMD ["--host=0.0.0.0", "--rtorrent"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I did not think of the ramifications of moving flood from the entrypoint to the command. Keeping it in the entrypoint should mean it will work the way the documentation expects it too.

Let me know if you want me to move the other flags to the entrypoint as well or if they are expected to be defaults we could leave them out.

 Sorry!

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
