### PR TITLE
feat: use env instead of args in docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Note that you have to let Docker know which port should be exposed (e.g. `-p 300
 
 Don't forget to pay attention to `flood`'s environment variables like `FLOOD_OPTION_PORT` and `FLOOD_OPTION_ALLOWEDPATH` (e.g. `-e FLOOD_OPTION_PORT="3000"`) To view more available environment options see [here](https://github.com/jesec/flood/blob/master/config.ts).
 
+It is also possible to pass in arguments to the docker run command (e.g. `docker run jesec/flood flood --port="3000"`)
+
+Don't forget to pay attention to `flood`'s arguments like `--port` and `--allowedpath`.
+
 Checkout [Run Flood (and torrent clients) in containers](https://github.com/jesec/flood/discussions/120) discussion.
 
 Filesystem parts in [Troubleshooting](https://github.com/jesec/flood#troubleshooting) are especially important for containers.

--- a/README.md
+++ b/README.md
@@ -95,11 +95,9 @@ To upgrade, `docker pull jesec/flood`.
 
 Note that you have to let Docker know which port should be exposed (e.g. `-p 3000:3000`) and folder mapping (e.g. `-v /data:/data`).
 
-Don't forget to pay attention to `flood`'s environment variables like `FLOOD_OPTION_PORT` and `FLOOD_OPTION_ALLOWEDPATH` (e.g. `-e FLOOD_OPTION_PORT="3000"`) To view more available environment options see [here](https://github.com/jesec/flood/blob/master/config.ts).
-
-It is also possible to pass in arguments to the docker run command (e.g. `docker run jesec/flood --port="3000"`)
-
 Don't forget to pay attention to `flood`'s arguments like `--port` and `--allowedpath`.
+
+Alternatively you can pass in environment variables like `FLOOD_OPTION_PORT` and `FLOOD_OPTION_ALLOWEDPATH` (e.g. `-e FLOOD_OPTION_PORT="3000"`) To view more available environment options see [here](https://github.com/jesec/flood/blob/master/config.ts).
 
 Checkout [Run Flood (and torrent clients) in containers](https://github.com/jesec/flood/discussions/120) discussion.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Note that you have to let Docker know which port should be exposed (e.g. `-p 300
 
 Don't forget to pay attention to `flood`'s arguments like `--port` and `--allowedpath`.
 
-Alternatively you can pass in environment variables like `FLOOD_OPTION_PORT` and `FLOOD_OPTION_ALLOWEDPATH` (e.g. `-e FLOOD_OPTION_PORT="3000"`) To view more available environment options see [here](https://github.com/jesec/flood/blob/master/config.ts).
+Alternatively you can pass in environment variables like `FLOOD_OPTION_PORT` and `FLOOD_OPTION_ALLOWEDPATH` (e.g. `-e FLOOD_OPTION_PORT="3000"`) To view more configurations options see [here](https://github.com/jesec/flood#configuration).
 
 Checkout [Run Flood (and torrent clients) in containers](https://github.com/jesec/flood/discussions/120) discussion.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To upgrade, `docker pull jesec/flood`.
 
 Note that you have to let Docker know which port should be exposed (e.g. `-p 3000:3000`) and folder mapping (e.g. `-v /data:/data`).
 
-Don't forget to pay attention to `flood`'s arguments like `--port` and `--allowedpath`.
+Don't forget to pay attention to `flood`'s environment variables like `FLOOD_OPTION_PORT` and `FLOOD_OPTION_ALLOWEDPATH` (e.g. `-e FLOOD_OPTION_PORT="3000"`) To view more available environment options see [here](https://github.com/jesec/flood/blob/master/config.ts).
 
 Checkout [Run Flood (and torrent clients) in containers](https://github.com/jesec/flood/discussions/120) discussion.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Note that you have to let Docker know which port should be exposed (e.g. `-p 300
 
 Don't forget to pay attention to `flood`'s environment variables like `FLOOD_OPTION_PORT` and `FLOOD_OPTION_ALLOWEDPATH` (e.g. `-e FLOOD_OPTION_PORT="3000"`) To view more available environment options see [here](https://github.com/jesec/flood/blob/master/config.ts).
 
-It is also possible to pass in arguments to the docker run command (e.g. `docker run jesec/flood flood --port="3000"`)
+It is also possible to pass in arguments to the docker run command (e.g. `docker run jesec/flood --port="3000"`)
 
 Don't forget to pay attention to `flood`'s arguments like `--port` and `--allowedpath`.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Note that you have to let Docker know which port should be exposed (e.g. `-p 300
 
 Don't forget to pay attention to `flood`'s arguments like `--port` and `--allowedpath`.
 
-Alternatively you can pass in environment variables like `FLOOD_OPTION_PORT` and `FLOOD_OPTION_ALLOWEDPATH` (e.g. `-e FLOOD_OPTION_PORT="3000"`) To view more configurations options see [here](https://github.com/jesec/flood#configuration).
+Alternatively, you can pass in environment variables instead (e.g. `-e FLOOD_OPTION_port=3000`).
 
 Checkout [Run Flood (and torrent clients) in containers](https://github.com/jesec/flood/discussions/120) discussion.
 

--- a/distribution/containers/Dockerfile.distroless
+++ b/distribution/containers/Dockerfile.distroless
@@ -6,16 +6,20 @@ WORKDIR /root
 
 # Install Flood and dependencies to /bin
 RUN mkdir -p /root/sysroot/bin
+
 COPY ./artifacts artifacts
-RUN \ 
-    apk --no-cache add tini \
-    if [[ `uname -m` == "aarch64" ]]; \
+RUN if [[ `uname -m` == "aarch64" ]]; \
     then mv artifacts/flood-linux-arm64 flood; \
     elif [[ `uname -m` == "x86_64" ]]; \
     then mv artifacts/flood-linux-x64 flood; \
     fi
 RUN mv flood /root/sysroot/bin/flood
+
 COPY --from=busybox /bin/busybox_DF /root/sysroot/bin/df
+
+RUN apk --no-cache add tini-static
+RUN cp /sbin/tini-static /root/sysroot/bin/tini
+
 RUN chmod 0555 /root/sysroot/bin/*
 
 # Create 1001:1001 user
@@ -26,19 +30,17 @@ RUN chown 1001:1001 /root/sysroot/home/download
 FROM scratch as flood
 
 COPY --from=build /root/sysroot /
-COPY --from=build /sbin/tini /sbin/tini
 
 # Run as 1001:1001 user
 ENV HOME=/home/download
-ENV FLOOD_OPTION_HOST="0.0.0.0"
-ENV FLOOD_OPTION_PORT="3000"
 USER 1001:1001
 
 # Expose port 3000
 EXPOSE 3000
 
 # Flood
-ENTRYPOINT ["/sbin/tini", "--", "flood"]
+ENV FLOOD_OPTION_HOST="0.0.0.0"
+ENTRYPOINT ["/bin/tini", "--", "flood"]
 
 # rtorrent-flood image
 FROM jesec/rtorrent:master as rtorrent
@@ -47,13 +49,5 @@ FROM flood as rtorrent-flood
 # Install rTorrent
 COPY --from=rtorrent / /
 
-# Install tini
-COPY --from=build /sbin/tini /sbin/tini
-
-ENV HOME=/home/download
-ENV FLOOD_OPTION_HOST="0.0.0.0"
-ENV FLOOD_OPTION_PORT="3000"
-ENV FLOOD_OPTION_RTORRENT="true"
-
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["/sbin/tini", "--", "flood"]
+ENV FLOOD_OPTION_RTORRENT="true"

--- a/distribution/containers/Dockerfile.distroless
+++ b/distribution/containers/Dockerfile.distroless
@@ -39,8 +39,7 @@ USER 1001:1001
 EXPOSE 3000
 
 # Flood
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["flood"]
+ENTRYPOINT ["/sbin/tini", "--", "flood"]
 
 # rtorrent-flood image
 FROM jesec/rtorrent:master as rtorrent
@@ -59,5 +58,4 @@ ENV \
     FLOOD_OPTION_RTORRENT="true"
 
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["flood"]
+ENTRYPOINT ["/sbin/tini", "--", "flood"]

--- a/distribution/containers/Dockerfile.distroless
+++ b/distribution/containers/Dockerfile.distroless
@@ -7,7 +7,9 @@ WORKDIR /root
 # Install Flood and dependencies to /bin
 RUN mkdir -p /root/sysroot/bin
 COPY ./artifacts artifacts
-RUN if [[ `uname -m` == "aarch64" ]]; \
+RUN \ 
+    apk --no-cache add tini \
+    if [[ `uname -m` == "aarch64" ]]; \
     then mv artifacts/flood-linux-arm64 flood; \
     elif [[ `uname -m` == "x86_64" ]]; \
     then mv artifacts/flood-linux-x64 flood; \
@@ -24,16 +26,21 @@ RUN chown 1001:1001 /root/sysroot/home/download
 FROM scratch as flood
 
 COPY --from=build /root/sysroot /
+COPY --from=build /sbin/tini /sbin/tini
 
 # Run as 1001:1001 user
-ENV HOME=/home/download
+ENV \
+    HOME=/home/download \
+    FLOOD_OPTION_HOST="0.0.0.0" \
+    FLOOD_OPTION_PORT="3000"
 USER 1001:1001
 
 # Expose port 3000
 EXPOSE 3000
 
 # Flood
-ENTRYPOINT ["flood", "--host=0.0.0.0"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["flood"]
 
 # rtorrent-flood image
 FROM jesec/rtorrent:master as rtorrent
@@ -42,5 +49,15 @@ FROM flood as rtorrent-flood
 # Install rTorrent
 COPY --from=rtorrent / /
 
+# Install tini
+COPY --from=build /sbin/tini /sbin/tini
+
+ENV \
+    HOME=/home/download \
+    FLOOD_OPTION_HOST="0.0.0.0" \
+    FLOOD_OPTION_PORT="3000" \
+    FLOOD_OPTION_RTORRENT="true"
+
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["flood", "--host=0.0.0.0", "--rtorrent"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["flood"]

--- a/distribution/containers/Dockerfile.distroless
+++ b/distribution/containers/Dockerfile.distroless
@@ -29,10 +29,9 @@ COPY --from=build /root/sysroot /
 COPY --from=build /sbin/tini /sbin/tini
 
 # Run as 1001:1001 user
-ENV \
-    HOME=/home/download \
-    FLOOD_OPTION_HOST="0.0.0.0" \
-    FLOOD_OPTION_PORT="3000"
+ENV HOME=/home/download
+ENV FLOOD_OPTION_HOST="0.0.0.0"
+ENV FLOOD_OPTION_PORT="3000"
 USER 1001:1001
 
 # Expose port 3000
@@ -51,11 +50,10 @@ COPY --from=rtorrent / /
 # Install tini
 COPY --from=build /sbin/tini /sbin/tini
 
-ENV \
-    HOME=/home/download \
-    FLOOD_OPTION_HOST="0.0.0.0" \
-    FLOOD_OPTION_PORT="3000" \
-    FLOOD_OPTION_RTORRENT="true"
+ENV HOME=/home/download
+ENV FLOOD_OPTION_HOST="0.0.0.0"
+ENV FLOOD_OPTION_PORT="3000"
+ENV FLOOD_OPTION_RTORRENT="true"
 
 # Flood with managed rTorrent daemon
 ENTRYPOINT ["/sbin/tini", "--", "flood"]

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -30,5 +30,4 @@ USER download
 EXPOSE 3000
 
 # Flood
-ENTRYPOINT ["/sbin/tini", "--", 
-CMD ["flood"]
+ENTRYPOINT ["/sbin/tini", "--", "flood"]

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -21,7 +21,6 @@ RUN adduser -h /home/download -s /sbin/nologin --disabled-password download
 # Run as "download" user
 USER download
 
-ENV HOME=/home/download
 ENV FLOOD_OPTION_HOST="0.0.0.0"
 ENV FLOOD_OPTION_PORT="3000"
 

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -21,10 +21,9 @@ RUN adduser -h /home/download -s /sbin/nologin --disabled-password download
 # Run as "download" user
 USER download
 
-ENV \
-    HOME=/home/download \
-    FLOOD_OPTION_HOST="0.0.0.0" \
-    FLOOD_OPTION_PORT="3000"
+ENV HOME=/home/download
+ENV FLOOD_OPTION_HOST="0.0.0.0"
+ENV FLOOD_OPTION_PORT="3000"
 
 # Expose port 3000
 EXPOSE 3000

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -4,11 +4,6 @@ FROM node:alpine
 ARG PACKAGE=flood
 ARG VERSION=latest
 
-ENV \
-    HOME=/home/download \
-    FLOOD_OPTION_HOST="0.0.0.0" \
-    FLOOD_OPTION_PORT="3000"
-
 # Get specified version from npm
 RUN npm i -g "${PACKAGE}"@"${VERSION}" &&\
     node --version &&\
@@ -25,6 +20,11 @@ RUN adduser -h /home/download -s /sbin/nologin --disabled-password download
 
 # Run as "download" user
 USER download
+
+ENV \
+    HOME=/home/download \
+    FLOOD_OPTION_HOST="0.0.0.0" \
+    FLOOD_OPTION_PORT="3000"
 
 # Expose port 3000
 EXPOSE 3000

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -21,11 +21,9 @@ RUN adduser -h /home/download -s /sbin/nologin --disabled-password download
 # Run as "download" user
 USER download
 
-ENV FLOOD_OPTION_HOST="0.0.0.0"
-ENV FLOOD_OPTION_PORT="3000"
-
 # Expose port 3000
 EXPOSE 3000
 
 # Flood
+ENV FLOOD_OPTION_HOST="0.0.0.0"
 ENTRYPOINT ["/sbin/tini", "--", "flood"]

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -4,6 +4,11 @@ FROM node:alpine
 ARG PACKAGE=flood
 ARG VERSION=latest
 
+ENV \
+    HOME=/home/download \
+    FLOOD_OPTION_HOST="0.0.0.0" \
+    FLOOD_OPTION_PORT="3000"
+
 # Get specified version from npm
 RUN npm i -g "${PACKAGE}"@"${VERSION}" &&\
     node --version &&\
@@ -25,4 +30,5 @@ USER download
 EXPOSE 3000
 
 # Flood
-ENTRYPOINT ["/sbin/tini", "--", "flood", "--host=0.0.0.0"]
+ENTRYPOINT ["/sbin/tini", "--", 
+CMD ["flood"]

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -15,5 +15,4 @@ ENV \
 COPY --from=rtorrent / /
 
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["flood"]
+ENTRYPOINT ["/sbin/tini", "--", "flood"]

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -5,8 +5,15 @@ FROM jesec/rtorrent:$RTORRENT_VERSION as rtorrent
 
 FROM jesec/flood:$FLOOD_VERSION as flood
 
+ENV \
+    HOME=/home/download \
+    FLOOD_OPTION_HOST="0.0.0.0" \
+    FLOOD_OPTION_PORT="3000" \
+    FLOOD_OPTION_RTORRENT="true"
+
 # Install rTorrent
 COPY --from=rtorrent / /
 
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["/sbin/tini", "--", "flood", "--host=0.0.0.0", "--rtorrent"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["flood"]

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -5,11 +5,10 @@ FROM jesec/rtorrent:$RTORRENT_VERSION as rtorrent
 
 FROM jesec/flood:$FLOOD_VERSION as flood
 
-ENV \
-    HOME=/home/download \
-    FLOOD_OPTION_HOST="0.0.0.0" \
-    FLOOD_OPTION_PORT="3000" \
-    FLOOD_OPTION_RTORRENT="true"
+ENV HOME=/home/download
+ENV FLOOD_OPTION_HOST="0.0.0.0"
+ENV FLOOD_OPTION_PORT="3000"
+ENV FLOOD_OPTION_RTORRENT="true"
 
 # Install rTorrent
 COPY --from=rtorrent / /

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -5,7 +5,6 @@ FROM jesec/rtorrent:$RTORRENT_VERSION as rtorrent
 
 FROM jesec/flood:$FLOOD_VERSION as flood
 
-ENV HOME=/home/download
 ENV FLOOD_OPTION_HOST="0.0.0.0"
 ENV FLOOD_OPTION_PORT="3000"
 ENV FLOOD_OPTION_RTORRENT="true"

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -5,12 +5,8 @@ FROM jesec/rtorrent:$RTORRENT_VERSION as rtorrent
 
 FROM jesec/flood:$FLOOD_VERSION as flood
 
-ENV FLOOD_OPTION_HOST="0.0.0.0"
-ENV FLOOD_OPTION_PORT="3000"
-ENV FLOOD_OPTION_RTORRENT="true"
-
 # Install rTorrent
 COPY --from=rtorrent / /
 
 # Flood with managed rTorrent daemon
-ENTRYPOINT ["/sbin/tini", "--", "flood"]
+ENV FLOOD_OPTION_RTORRENT="true"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This sets up the defaults in the docker container to use config from env instead of args

## Related Issue

As discussed here https://github.com/jesec/flood/pull/261

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
