### PR TITLE
server: qBittorent: fix getClientSessionDirectory on Linux

### DIFF
--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import {homedir} from 'os';
 import parseTorrent from 'parse-torrent';
 import path from 'path';
@@ -430,7 +431,12 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
       case 'darwin':
         return {path: path.join(homedir(), '/Library/Application Support/qBittorrent/BT_backup'), case: 'lower'};
       default:
-        return {path: path.join(homedir(), '/.local/share/data/qBittorrent/BT_backup'), case: 'lower'};
+        const legacyPath = path.join(homedir(), '/.local/share/data/qBittorrent/BT_backup');
+        if (fs.existsSync(legacyPath)) {
+          return {path: legacyPath, case: 'lower'};
+        } else {
+          return {path: path.join(homedir(), '/.local/share/qBittorrent/BT_backup'), case: 'lower'};
+        }
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I was getting a 500 on `GET /api/torrents/{hash}/metainfo`

By looking at the code, I guessed Flood wasn't able to find the torrent file.

Indeed, my qBittorent folder isn't the same as the one in the code:

```
qbt@sana ~> ll .local/share/data/
ls: cannot access '.local/share/data/': No such file or directory
qbt@sana ~> ll .local/share/qBittorrent/
total 164K
drwxr-xr-x 2 qbt qbt 144K Apr 10 00:44 BT_backup/
drwxr-xr-x 2 qbt qbt 4.0K Jan 24 19:27 GeoDB/
drwxr-xr-x 2 qbt qbt 4.0K Apr 10 00:33 logs/
drwxr-xr-x 3 qbt qbt 4.0K Mar 31 21:18 nova3/
drwxr-xr-x 3 qbt qbt 4.0K Jan 24 19:27 rss/
```

By looking at the qbt source code, it looks like the one hardcoded in Flood is the "legacy" one:

```cpp
    // On Linux keep using the legacy directory ~/.local/share/data/ if it exists
    const QString legacyDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
        + QLatin1String("/data/") + profileName() + QLatin1Char('/');

    const QString dataDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
        + QLatin1Char('/') + profileName() + QLatin1Char('/');

    if (!QDir(dataDir).exists() && QDir(legacyDir).exists())
    {
        qWarning("The legacy data directory '%s' is used. It is recommended to move its content to '%s'",
            qUtf8Printable(legacyDir), qUtf8Printable(dataDir));

        return legacyDir;
    }

    return dataDir;
```

https://github.com/qbittorrent/qBittorrent/blob/2b8e50b296f52d058f6f049dc9f00212f6ffe0e0/src/base/profile_p.cpp#L79-L84

My PR fixes my case only, but maybe we should check for both and use the one that exists (or the newest if both)?

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
