### PR TITLE
doc: add flood-api, a JavaScript client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Flood is a monitoring service for various torrent clients. It's a Node.js servic
 | [qBittorrent](https://github.com/qbittorrent/qBittorrent) v4.1+ | :white_check_mark: ([tested](https://github.com/jesec/flood/blob/master/server/.jest/qbittorrent.setup.js))  |
 | [Transmission](https://github.com/transmission/transmission)    | :white_check_mark: ([tested](https://github.com/jesec/flood/blob/master/server/.jest/transmission.setup.js)) |
 
+#### Integrating with Flood
+
+APIs are officially documented inline by the [comments](https://github.com/jesec/flood/blob/f7019001dd81ee8401c87d4c4cd6da6f5f520611/server/routes/api/torrents.ts#L106-L117) and [types](https://github.com/jesec/flood/blob/f7019001dd81ee8401c87d4c4cd6da6f5f520611/shared/schema/api/torrents.ts#L10-L32).
+
+You can also check out:
+
+- [community documentation site](https://flood-api.netlify.app)
+- [list of unofficial client API libraries](https://github.com/jesec/flood/wiki/List-of-unofficial-client-API-libraries)
+- [list of unofficial API integrations](https://github.com/jesec/flood/wiki/List-of-unofficial-API-integrations)
+
+Flood conforms to [Semantic Versioning](https://semver.org) conventions.
+
 #### Feedback
 
 If you have a specific issue or bug, please file a [GitHub issue](https://github.com/jesec/flood/issues). Please join the [Flood Discord server](https://discord.gg/Z7yR5Uf) to discuss feature requests and implementation details.


### PR DESCRIPTION
Hey

I created [flood-api](https://github.com/sabersalv/flood-api), a JavaScript API wrapper for flood, with a clean footprint and a [beautiful API documentation](https://flood-api.netlify.app/).

Can you include it in the README? So that it can benefit everyone in the open-source community. 

Thanks