### PR TITLE
fix: change the cookie sameSite to lax

### DIFF
--- a/server/util/authUtil.ts
+++ b/server/util/authUtil.ts
@@ -10,7 +10,7 @@ const EXPIRATION_SECONDS = 60 * 60 * 24 * 7; // one week
 export const getCookieOptions = (): CookieOptions => ({
   expires: new Date(Date.now() + EXPIRATION_SECONDS * 1000),
   httpOnly: true,
-  sameSite: 'strict',
+  sameSite: 'lax',
 });
 
 export const getAuthToken = (username: string, iat?: number): string => {


### PR DESCRIPTION
## Description

I'm building an web app that interact with Flood. And I want to implement this feature, the app list torrents with download torrent links (e.g. `http://flood/api/torrents/hash/metainfo`), when user click it, it follows the link to flood site and download the torrent file. According to [this article](https://web.dev/samesite-cookies-explained/), needs set the sameStite to `Lax`

With sameSite to `Strict`, the followed link will show `unauthorized` error.
With sameSite set to `Lax`, the followed link works

Combine with https://github.com/jesec/flood/pull/316, you can download the torrent and save it into a meaningfull name.
