### PR TITLE
Skip docker overlayfs mount point

### DIFF
--- a/server/util/diskUsageUtil.ts
+++ b/server/util/diskUsageUtil.ts
@@ -48,7 +48,7 @@ export const diskUsage: Readonly<Record<SupportedPlatform, (timeout: number) => 
         .slice(1)
         .map((disk) => disk.split(/\s+/))
         .filter((disk) => filterMountPoint(disk[6]))
-        .filter((disk) => disk[1] !== 'devtmpfs' && disk[1] !== 'squashfs' && disk[1] !== 'tmpfs')
+        .filter((disk) => !['devtmpfs', 'squashfs', 'tmpfs', 'overlay'].includes(disk[1]))
         .map(([_dev, _fs, size, used, avail, _pcent, target]) => {
           return {
             size: Number.parseInt(size, 10) * 1024,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

docker will mount some overlay fs, and get displayed when running `df -T`

```text
...
overlay         overlay   236937040   65102840 159728780   29% /var/lib/docker/overlay2/72e95b1a20e559eb6d8f10d888365f898bf5da17c09cd6d2ba3fe5c0aa7c22b5/merged
overlay         overlay   236937040   65102840 159728780   29% /var/lib/docker/overlay2/cef03d67bf64ff7addc78d7938dedd6a0dcb4943412e4a9bb5b7083507420b55/merged
```

this mount path should be omitted by diskUsage util.

## Related Issue

No

## Screenshots

No
## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [X] Bug fix (non-breaking change which fixes an issue - semver PATCH)
