### PR TITLE
fix: RSS feed rule edit

### DIFF
--- a/server/services/feedService.ts
+++ b/server/services/feedService.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import Datastore from 'nedb-promises';
+import {remove} from 'lodash';
 
 import type {FeedItem} from 'feedsub';
 
@@ -328,6 +329,10 @@ class FeedService extends BaseService {
     if (feedReaderToRemove != null) {
       feedReaderToRemove.stopReader();
       this.feedReaders.splice(feedReaderToRemoveIndex, 1);
+    }
+
+    for (const rule of Object.values(this.rules)) {
+      remove(rule, (v) => v._id === id);
     }
 
     return this.db.remove({_id: id}, {}).then(() => undefined);

--- a/server/services/feedService.ts
+++ b/server/services/feedService.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import Datastore from 'nedb-promises';
-import {remove} from 'lodash';
 
 import type {FeedItem} from 'feedsub';
 
@@ -331,8 +330,8 @@ class FeedService extends BaseService {
       this.feedReaders.splice(feedReaderToRemoveIndex, 1);
     }
 
-    for (const rule of Object.values(this.rules)) {
-      remove(rule, (v) => v._id === id);
+    for (const [key, rule] of Object.entries(this.rules)) {
+      this.rules[key] = rule.filter((rule) => rule._id !== id);
     }
 
     return this.db.remove({_id: id}, {}).then(() => undefined);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Edit a RSS rule calls `removeItem`, then `addRule`
2. `addRule` keep pushing rule into `this.rules`

https://github.com/jesec/flood/blob/6aac6486efbb360a24b6b8370156928cf5f6b910/server/services/feedService.ts#L181 

3. But `removeItem` does not remove rule from `this.rules`

4. That caused the problem, edit a rule may not work. When you edit the rule multpile times, `this.rules` becomes larger and larger, old rules are never get removed.

In the future, can create a new `editRule` api for simplication.

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
