### PR TITLE
feat: display selected count and size on context menu

### DIFF
--- a/client/src/javascript/components/general/ContextMenuMountPoint.tsx
+++ b/client/src/javascript/components/general/ContextMenuMountPoint.tsx
@@ -51,7 +51,7 @@ const ContextMenuMountPoint: FC<ContextMenuMountPointProps> = observer(({id}: Co
                   className={classnames('menu__item__label--primary', {
                     'has-action': item.labelAction,
                   })}>
-                  <span className="menu__item__label">{i18n._(item.label)}</span>
+                  <span className="menu__item__label">{item.labelComp ? <item.labelComp /> : i18n._(item.label)}</span>
                   {item.labelAction ? (
                     <span className="menu__item__label__action">
                       <item.labelAction />

--- a/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
@@ -38,7 +38,17 @@ const InlineTorrentPropertyCheckbox: FC<{property: keyof TorrentProperties}> = o
 const getContextMenuItems = (torrent: TorrentProperties): Array<ContextMenuItem> => {
   const changePriorityFuncRef = createRef<() => number>();
 
-  const items: Array<ContextMenuItem> = [
+  return [
+    {
+      type: 'action',
+      action: 'selectedCount',
+      label: TorrentContextMenuActions.selectedCount,
+      labelComp: () => (
+        <Trans id="torrents.list.context.selected.count.text" values={{count: TorrentStore.selectedCount}} />
+      ),
+      labelAction: () => <Size value={TorrentStore.selectedSize} className="size" />,
+      clickHandler: () => null,
+    },
     {
       type: 'action',
       action: 'start',
@@ -230,27 +240,6 @@ const getContextMenuItems = (torrent: TorrentProperties): Array<ContextMenuItem>
       ),
     },
   ];
-
-  if (TorrentStore.selectedCount > 1) {
-    items.unshift(
-      {
-        type: 'action',
-        action: 'selectedCount',
-        label: TorrentContextMenuActions.selectedCount,
-        labelComp: () => (
-          <Trans id="torrents.list.context.selected.count.text" values={{count: TorrentStore.selectedCount}} />
-        ),
-        labelAction: () => <Size value={TorrentStore.selectedSize} className="size" />,
-        clickHandler: () => null,
-      },
-      {
-        type: 'separator',
-        forAction: 'selectedCount',
-      },
-    );
-  }
-
-  return items;
 };
 
 export default {

--- a/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
@@ -1,5 +1,6 @@
 import {createRef, FC, MutableRefObject} from 'react';
 import {observer} from 'mobx-react';
+import {Trans} from '@lingui/react';
 
 import {Checkmark} from '@client/ui/icons';
 import ConfigStore from '@client/stores/ConfigStore';
@@ -7,6 +8,8 @@ import TorrentActions from '@client/actions/TorrentActions';
 import TorrentContextMenuActions from '@client/constants/TorrentContextMenuActions';
 import TorrentStore from '@client/stores/TorrentStore';
 import UIActions from '@client/actions/UIActions';
+
+import Size from '@client/components/general/Size';
 
 import type {ContextMenuItem} from '@client/stores/UIStore';
 
@@ -35,7 +38,7 @@ const InlineTorrentPropertyCheckbox: FC<{property: keyof TorrentProperties}> = o
 const getContextMenuItems = (torrent: TorrentProperties): Array<ContextMenuItem> => {
   const changePriorityFuncRef = createRef<() => number>();
 
-  return [
+  const items: Array<ContextMenuItem> = [
     {
       type: 'action',
       action: 'start',
@@ -227,6 +230,27 @@ const getContextMenuItems = (torrent: TorrentProperties): Array<ContextMenuItem>
       ),
     },
   ];
+
+  if (TorrentStore.selectedCount > 1) {
+    items.unshift(
+      {
+        type: 'action',
+        action: 'selectedCount',
+        label: TorrentContextMenuActions.selectedCount,
+        labelComp: () => (
+          <Trans id="torrents.list.context.selected.count.text" values={{count: TorrentStore.selectedCount}} />
+        ),
+        labelAction: () => <Size value={TorrentStore.selectedSize} className="size" />,
+        clickHandler: () => null,
+      },
+      {
+        type: 'separator',
+        forAction: 'selectedCount',
+      },
+    );
+  }
+
+  return items;
 };
 
 export default {

--- a/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
@@ -50,6 +50,9 @@ const getContextMenuItems = (torrent: TorrentProperties): Array<ContextMenuItem>
       clickHandler: () => null,
     },
     {
+      type: 'separator',
+    },
+    {
       type: 'action',
       action: 'start',
       label: TorrentContextMenuActions.start,

--- a/client/src/javascript/components/torrent-list/TorrentListRow.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListRow.tsx
@@ -39,6 +39,9 @@ const displayContextMenu = (hash: string, event: KeyboardEvent | MouseEvent | To
     },
     items: TorrentListContextMenu.getContextMenuItems(torrent).filter((item) => {
       if (item.type === 'separator') {
+        if (item.forAction) {
+          return torrentContextMenuActions.some((action) => action.id === item.forAction && action.visible);
+        }
         return true;
       }
 

--- a/client/src/javascript/components/torrent-list/TorrentListRow.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListRow.tsx
@@ -31,25 +31,30 @@ const displayContextMenu = (hash: string, event: KeyboardEvent | MouseEvent | To
   const {torrentContextMenuActions = defaultFloodSettings.torrentContextMenuActions} = SettingStore.floodSettings;
   const torrent = TorrentStore.torrents[hash];
 
+  const items = TorrentListContextMenu.getContextMenuItems(torrent).filter((item) => {
+    if (item.type === 'separator') {
+      return true;
+    }
+
+    return torrentContextMenuActions.some((action) => {
+      const visible = action.id === item.action && action.visible === true;
+      if (item.action === 'selectedCount') {
+        return visible && TorrentStore.selectedCount > 1;
+      }
+      return visible;
+    });
+  });
+  if (items[0].type === 'separator') {
+    items.shift();
+  }
+
   UIActions.displayContextMenu({
     id: 'torrent-list-item',
     clickPosition: {
       x: mouseClientX || touchClientX || 0,
       y: mouseClientY || touchClientY || 0,
     },
-    items: TorrentListContextMenu.getContextMenuItems(torrent).filter((item) => {
-      if (item.type === 'separator') {
-        return true;
-      }
-
-      return torrentContextMenuActions.some((action) => {
-        const visible = action.id === item.action && action.visible === true;
-        if (item.action === 'selectedCount') {
-          return visible && TorrentStore.selectedCount > 1;
-        }
-        return visible;
-      });
-    }),
+    items,
   });
 };
 

--- a/client/src/javascript/components/torrent-list/TorrentListRow.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListRow.tsx
@@ -39,13 +39,16 @@ const displayContextMenu = (hash: string, event: KeyboardEvent | MouseEvent | To
     },
     items: TorrentListContextMenu.getContextMenuItems(torrent).filter((item) => {
       if (item.type === 'separator') {
-        if (item.forAction) {
-          return torrentContextMenuActions.some((action) => action.id === item.forAction && action.visible);
-        }
         return true;
       }
 
-      return torrentContextMenuActions.some((action) => action.id === item.action && action.visible === true);
+      return torrentContextMenuActions.some((action) => {
+        const visible = action.id === item.action && action.visible === true;
+        if (item.action === 'selectedCount') {
+          return visible && TorrentStore.selectedCount > 1;
+        }
+        return visible;
+      });
     }),
   });
 };

--- a/client/src/javascript/constants/TorrentContextMenuActions.ts
+++ b/client/src/javascript/constants/TorrentContextMenuActions.ts
@@ -14,6 +14,7 @@ const TorrentContextMenuActions = {
   setInitialSeeding: 'torrents.list.context.initial.seeding',
   setSequential: 'torrents.list.context.sequential',
   setPriority: 'torrents.list.context.priority',
+  selectedCount: 'torrents.list.context.selected.count.label',
 } as const;
 
 export default TorrentContextMenuActions;

--- a/client/src/javascript/i18n/strings/en.json
+++ b/client/src/javascript/i18n/strings/en.json
@@ -334,6 +334,8 @@
   "torrents.list.context.set.trackers": "Set Trackers",
   "torrents.list.context.start": "Start",
   "torrents.list.context.stop": "Stop",
+  "torrents.list.context.selected.count.label": "Selected Count",
+  "torrents.list.context.selected.count.text": "{count} Selected",
   "torrents.list.drop": "Drop files here to add them.",
   "torrents.list.no.torrents": "No torrents to display.",
   "torrents.move.button.set.location": "Set Location",

--- a/client/src/javascript/stores/TorrentStore.ts
+++ b/client/src/javascript/stores/TorrentStore.ts
@@ -56,6 +56,14 @@ class TorrentStore {
     return filteredTorrents;
   }
 
+  @computed get selectedCount(): number {
+    return this.selectedTorrents.length;
+  }
+
+  @computed get selectedSize(): number {
+    return this.selectedTorrents.reduce((sum, hash) => sum + this.torrents[hash].sizeBytes, 0);
+  }
+
   setSelectedTorrents({event, hash}: {event: React.KeyboardEvent | React.MouseEvent | React.TouchEvent; hash: string}) {
     this.selectedTorrents = selectTorrents({
       event,

--- a/client/src/javascript/stores/UIStore.ts
+++ b/client/src/javascript/stores/UIStore.ts
@@ -8,6 +8,7 @@ export type ContextMenuItem =
       type: 'action';
       action: TorrentContextMenuAction;
       label: string;
+      labelComp?: FC;
       labelAction?: FC;
       labelSecondary?: FC;
       clickHandler(event: MouseEvent): void;
@@ -15,6 +16,7 @@ export type ContextMenuItem =
     }
   | {
       type: 'separator';
+      forAction?: string;
     };
 
 export interface ActiveContextMenu {

--- a/shared/constants/defaultFloodSettings.ts
+++ b/shared/constants/defaultFloodSettings.ts
@@ -49,6 +49,7 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
     tags: 100,
   },
   torrentContextMenuActions: [
+    {id: 'selectedCount', visible: false},
     {id: 'start', visible: true},
     {id: 'stop', visible: true},
     {id: 'remove', visible: true},
@@ -64,7 +65,6 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
     {id: 'setInitialSeeding', visible: false},
     {id: 'setSequential', visible: false},
     {id: 'setPriority', visible: false},
-    {id: 'selectedCount', visible: false},
   ],
   torrentListViewSize: 'condensed',
   speedLimits: {

--- a/shared/constants/defaultFloodSettings.ts
+++ b/shared/constants/defaultFloodSettings.ts
@@ -64,6 +64,7 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
     {id: 'setInitialSeeding', visible: false},
     {id: 'setSequential', visible: false},
     {id: 'setPriority', visible: false},
+    {id: 'selectedCount', visible: false},
   ],
   torrentListViewSize: 'condensed',
   speedLimits: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When you selected multiple items, righ click will give you information about the selected count and size. 
The info will not show up if you only selected 1 item.
You can enable/disable it in the settings.

A very useful feature when you want to know how many items you have selected.

## Screenshots

<img width="197" alt="Screen Shot 2021-07-31 at 3 04 01 PM" src="https://user-images.githubusercontent.com/2525544/127732131-740e478c-82d8-4a93-8acc-f3f94262b022.png">

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
