### PR TITLE
feat: display selected count and size on action bar

### DIFF
--- a/client/src/javascript/components/torrent-list/ActionBar.tsx
+++ b/client/src/javascript/components/torrent-list/ActionBar.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import {FC} from 'react';
 import {observer} from 'mobx-react';
-import {useLingui} from '@lingui/react';
+import {useLingui, Trans} from '@lingui/react';
 
 import {Add, Menu, Remove, Start, Stop} from '@client/ui/icons';
 import SettingActions from '@client/actions/SettingActions';
@@ -10,6 +10,7 @@ import TorrentActions from '@client/actions/TorrentActions';
 import TorrentStore from '@client/stores/TorrentStore';
 import UIActions from '@client/actions/UIActions';
 
+import Size from '@client/components/general/Size';
 import Action from './Action';
 import SortDropdown from './SortDropdown';
 
@@ -46,6 +47,14 @@ const ActionBar: FC = observer(() => {
           selectedProperty={sortBy != null ? sortBy.property : 'dateAdded'}
         />
       </div>
+      {TorrentStore.selectedCount > 0 && (
+        <div className="actions action-bar__item action-bar__item--selected-status">
+          <span>
+            <Trans id="actionbar.label.selected.count" values={{count: TorrentStore.selectedCount}} />
+          </span>
+          <Size className="size" value={TorrentStore.selectedSize} />
+        </div>
+      )}
       <div className="actions action-bar__item action-bar__item--torrent-operations">
         <div className="action-bar__group">
           <Action

--- a/client/src/javascript/components/torrent-list/ActionBar.tsx
+++ b/client/src/javascript/components/torrent-list/ActionBar.tsx
@@ -47,7 +47,7 @@ const ActionBar: FC = observer(() => {
           selectedProperty={sortBy != null ? sortBy.property : 'dateAdded'}
         />
       </div>
-      {TorrentStore.selectedCount > 0 && (
+      {TorrentStore.selectedCount > 1 && (
         <div className="actions action-bar__item action-bar__item--selected-status">
           <span>
             <Trans id="actionbar.label.selected.count" values={{count: TorrentStore.selectedCount}} />

--- a/client/src/javascript/i18n/strings/en.json
+++ b/client/src/javascript/i18n/strings/en.json
@@ -3,6 +3,7 @@
   "actionbar.button.remove.torrent": "Remove Torrent",
   "actionbar.button.start.torrent": "Start Torrent",
   "actionbar.button.stop.torrent": "Stop Torrent",
+  "actionbar.label.selected.count": "{count} Items",
   "alert.settings.saved": "Successfully saved settings.",
   "alert.torrent.add": "Successfully added {countElement} {count, plural, =1 {torrent} other {torrents}}.",
   "alert.torrent.add.failed": "Failed to add {countElement} {count, plural, =1 {torrent} other {torrents}}.",

--- a/client/src/javascript/stores/TorrentStore.ts
+++ b/client/src/javascript/stores/TorrentStore.ts
@@ -56,6 +56,14 @@ class TorrentStore {
     return filteredTorrents;
   }
 
+  @computed get selectedCount(): number {
+    return this.selectedTorrents.length;
+  }
+
+  @computed get selectedSize(): number {
+    return this.selectedTorrents.reduce((sum, hash) => sum + this.torrents[hash].sizeBytes, 0);
+  }
+
   setSelectedTorrents({event, hash}: {event: React.KeyboardEvent | React.MouseEvent | React.TouchEvent; hash: string}) {
     this.selectedTorrents = selectTorrents({
       event,

--- a/client/src/sass/components/_action-bar.scss
+++ b/client/src/sass/components/_action-bar.scss
@@ -56,10 +56,17 @@ $torrent-list--border: rgba(colors.$sidebar--background, 0.15);
       align-items: center;
       gap: 3px;
       color: #8899a8;
-      font-size: 0.8rem;
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+
+      .action-bar--is-condensed & {
+        font-size: 0.8rem;
+      }
+
+      @media (max-width: 375px) {
+        display: none;
+      }
 
       .size {
         &::before {

--- a/client/src/sass/components/_action-bar.scss
+++ b/client/src/sass/components/_action-bar.scss
@@ -57,7 +57,6 @@ $torrent-list--border: rgba(colors.$sidebar--background, 0.15);
       gap: 3px;
       color: #8899a8;
       font-size: 0.8rem;
-      margin-left: 3px;
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;

--- a/client/src/sass/components/_action-bar.scss
+++ b/client/src/sass/components/_action-bar.scss
@@ -36,7 +36,7 @@ $torrent-list--border: rgba(colors.$sidebar--background, 0.15);
     }
 
     &--sort-torrents {
-      flex: 1 0 auto;
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
 
@@ -48,6 +48,27 @@ $torrent-list--border: rgba(colors.$sidebar--background, 0.15);
 
       .action-bar--is-condensed & {
         display: none;
+      }
+    }
+
+    &--selected-status {
+      display: flex;
+      align-items: center;
+      gap: 3px;
+      color: #8899a8;
+      font-size: 0.8rem;
+      margin-left: 3px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+
+      .size {
+        &::before {
+          content: '(';
+        }
+        &::after {
+          content: ')';
+        }
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Will show up only if number of the selected items are larger than or equal to 2.

## Screenshots

<img width="1116" alt="Screen Shot 2021-08-02 at 11 59 47 PM" src="https://user-images.githubusercontent.com/2525544/127891102-1528e0e2-0c3a-4cbc-8fa4-5daaf104693b.png">
<img width="426" alt="Screen Shot 2021-08-03 at 12 00 49 AM" src="https://user-images.githubusercontent.com/2525544/127891111-32b7ae07-81c1-46c2-961d-cfc5432fad54.png">
<img width="320" alt="Screen Shot 2021-08-03 at 12 01 00 AM" src="https://user-images.githubusercontent.com/2525544/127891113-557e1e18-ad9e-4cd2-b4e9-39506117f0e7.png">
<img width="1132" alt="Screen Shot 2021-08-03 at 12 04 11 AM" src="https://user-images.githubusercontent.com/2525544/127891116-436f5d12-5fba-4c99-8f56-319ba8bef277.png">
<img width="429" alt="Screen Shot 2021-08-03 at 12 04 34 AM" src="https://user-images.githubusercontent.com/2525544/127891117-be4b0b3c-e50b-49b4-afb5-265afd424990.png">
<img width="320" alt="Screen Shot 2021-08-03 at 12 04 41 AM" src="https://user-images.githubusercontent.com/2525544/127891118-eb2090e0-841b-404c-9d35-258ab1a59ba7.png">

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
