### PR TITLE
client: add page title speed display preference

### DIFF
--- a/client/src/javascript/components/general/WindowTitle.tsx
+++ b/client/src/javascript/components/general/WindowTitle.tsx
@@ -3,15 +3,17 @@ import {observer} from 'mobx-react';
 import {useLingui} from '@lingui/react';
 
 import {compute, getTranslationString} from '../../util/size';
+import SettingStore from '../../stores/SettingStore';
 import TransferDataStore from '../../stores/TransferDataStore';
 
 const WindowTitle: FC = observer(() => {
+  const {UIPageTitleSpeedEnabled: enabled} = SettingStore.floodSettings;
   const {transferSummary: summary} = TransferDataStore;
   const {i18n} = useLingui();
 
   let title = 'Flood';
 
-  if (summary != null && Object.keys(summary).length > 0) {
+  if (enabled && summary != null && Object.keys(summary).length > 0) {
     const down = compute(summary.downRate);
     const up = compute(summary.upRate);
 

--- a/client/src/javascript/components/modals/settings-modal/UITab.tsx
+++ b/client/src/javascript/components/modals/settings-modal/UITab.tsx
@@ -10,6 +10,7 @@ import type {Language} from '@client/constants/Languages';
 import type {FloodSettings} from '@shared/types/FloodSettings';
 
 import ModalFormSectionHeader from '../ModalFormSectionHeader';
+import MiscUISettingsList from './lists/MiscUISettingsList';
 import TorrentContextMenuActionsList from './lists/TorrentContextMenuActionsList';
 import TorrentListColumnsList from './lists/TorrentListColumnsList';
 
@@ -98,6 +99,12 @@ const UITab: FC<UITabProps> = ({onSettingsChange}: UITabProps) => {
       </ModalFormSectionHeader>
       <FormRow>
         <TorrentContextMenuActionsList onSettingsChange={onSettingsChange} />
+      </FormRow>
+      <ModalFormSectionHeader>
+        <Trans id="settings.ui.misc" />
+      </ModalFormSectionHeader>
+      <FormRow>
+        <MiscUISettingsList onSettingsChange={onSettingsChange} />
       </FormRow>
     </Form>
   );

--- a/client/src/javascript/components/modals/settings-modal/lists/MiscUISettingsList.tsx
+++ b/client/src/javascript/components/modals/settings-modal/lists/MiscUISettingsList.tsx
@@ -1,0 +1,33 @@
+import {FC, useRef} from 'react';
+
+import SettingStore from '@client/stores/SettingStore';
+import ToggleList from '@client/components/general/ToggleList';
+
+import type {FloodSettings} from '@shared/types/FloodSettings';
+
+interface MiscUISettingsListProps {
+  onSettingsChange: (changedSettings: Partial<FloodSettings>) => void;
+}
+
+const MiscUISettingsList: FC<MiscUISettingsListProps> = ({onSettingsChange}: MiscUISettingsListProps) => {
+  const changedUIPageTitleSpeedEnabledRef = useRef<FloodSettings['UIPageTitleSpeedEnabled']>(
+    SettingStore.floodSettings.UIPageTitleSpeedEnabled,
+  );
+
+  return (
+    <ToggleList
+      items={[
+        {
+          label: 'settings.ui.page.title.speed',
+          defaultChecked: changedUIPageTitleSpeedEnabledRef.current,
+          onClick: () => {
+            changedUIPageTitleSpeedEnabledRef.current = !changedUIPageTitleSpeedEnabledRef.current;
+            onSettingsChange({UIPageTitleSpeedEnabled: changedUIPageTitleSpeedEnabledRef.current});
+          },
+        },
+      ]}
+    />
+  );
+};
+
+export default MiscUISettingsList;

--- a/client/src/javascript/i18n/strings/en.json
+++ b/client/src/javascript/i18n/strings/en.json
@@ -210,6 +210,8 @@
   "settings.ui.displayed.context.menu.items": "Context Menu Items",
   "settings.ui.displayed.details": "Torrent Detail Columns",
   "settings.ui.language": "Language",
+  "settings.ui.misc": "Miscellaneous",
+  "settings.ui.page.title.speed": "Display upload and download speed in page title",
   "settings.ui.locale": "Locale",
   "settings.ui.tag.selector.mode": "Tag Selector Preference",
   "settings.ui.tag.selector.mode.multi": "Multi Selection",

--- a/shared/constants/defaultFloodSettings.ts
+++ b/shared/constants/defaultFloodSettings.ts
@@ -74,6 +74,7 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
   mountPoints: [],
   deleteTorrentData: true,
   startTorrentsOnLoad: true,
+  UIPageTitleSpeedEnabled: true,
 };
 
 export default defaultFloodSettings;

--- a/shared/types/FloodSettings.ts
+++ b/shared/types/FloodSettings.ts
@@ -40,6 +40,9 @@ export interface FloodSettings {
 
   // Last used "Add Torrents" tab
   UITorrentsAddTab?: 'by-url' | 'by-file' | 'by-creation';
+
+  // Display upload and download speed in page title
+  UIPageTitleSpeedEnabled: boolean;
 }
 
 export type FloodSetting = keyof FloodSettings;


### PR DESCRIPTION
## Description

This PR adds a toggle under "User Interface" that toggles the display of upload and download speed in the page title.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
