### PR TITLE
client: fix loading indicator bar alignment

### DIFF
--- a/client/src/sass/components/_loading-indicator.scss
+++ b/client/src/sass/components/_loading-indicator.scss
@@ -20,9 +20,12 @@ $loading-indicator--tick--background--inverse: rgba(colors.$blue, 0.75);
 }
 
 .loading-indicator {
-  height: 18px;
-  position: relative;
   width: 32px;
+  height: 19px; // 3 * 3px bar height + 2 * 5px margin
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 
   &.is-inverse {
     .loading-indicator {
@@ -40,10 +43,7 @@ $loading-indicator--tick--background--inverse: rgba(colors.$blue, 0.75);
     background: $loading-indicator--bar--background;
     border-radius: 10px;
     height: 3px;
-    left: 0;
     overflow: hidden;
-    position: absolute;
-    transform: translateY(0);
     width: 100%;
 
     &:after {
@@ -57,22 +57,13 @@ $loading-indicator--tick--background--inverse: rgba(colors.$blue, 0.75);
       width: 25%;
     }
 
-    &--1 {
-      top: 0;
-    }
-
     &--2 {
-      top: 50%;
-      transform: translateY(-50%);
-
       &:after {
         animation-delay: 0.5s;
       }
     }
 
     &--3 {
-      bottom: 0;
-
       &:after {
         animation-delay: 1s;
       }


### PR DESCRIPTION
## Description

This PR fixes the alignment of the middle bar of the loading indicator on the loading overlay and changes it to use flex instead of absolute positioning.
The indicator had a total height of 18px and in it three bars with a height of 3px each. This left 9px for margins split into 4px and 5px.
The indicator now has a height of 19px which leaves 10px for margins split evenly into 5px each.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
