### PR TITLE
containers: add registry to image references

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,9 +8,9 @@
 #
 # Sources should be mounted to /workspaces/flood.
 
-FROM jesec/rtorrent:master as rtorrent
+FROM docker.io/jesec/rtorrent:master as rtorrent
 
-FROM ubuntu:focal as flood
+FROM docker.io/ubuntu:focal as flood
 
 COPY ./.devcontainer/library-scripts /tmp/library-scripts/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # publish the result image unless it was composed in a clean environment.
 
 ARG BUILDPLATFORM=amd64
-ARG NODE_IMAGE=node:alpine
+ARG NODE_IMAGE=docker.io/node:alpine
 
 FROM --platform=$BUILDPLATFORM ${NODE_IMAGE} as nodebuild
 
@@ -55,7 +55,7 @@ ENTRYPOINT ["npm", "--prefix=/usr/src/app/", "run", "start:development:server", 
 # docker exec -it ${container_id} npm --prefix=/usr/src/app/ run start:development:client
 
 # rtorrent-flood image
-FROM jesec/rtorrent:master as rtorrent
+FROM docker.io/jesec/rtorrent:master as rtorrent
 FROM flood as rtorrent-flood
 
 # Copy rTorrent

--- a/distribution/archlinux/Dockerfile.aur
+++ b/distribution/archlinux/Dockerfile.aur
@@ -1,4 +1,4 @@
-FROM archlinux
+FROM docker.io/archlinux
 
 ARG AUR_FOLDER
 ARG AUR_REPO

--- a/distribution/containers/Dockerfile.distroless
+++ b/distribution/containers/Dockerfile.distroless
@@ -1,6 +1,6 @@
-FROM jesec/busybox-applets as busybox
+FROM docker.io/jesec/busybox-applets as busybox
 
-FROM alpine as build
+FROM docker.io/alpine as build
 
 WORKDIR /root
 
@@ -43,7 +43,7 @@ ENV FLOOD_OPTION_HOST="0.0.0.0"
 ENTRYPOINT ["/bin/tini", "--", "flood"]
 
 # rtorrent-flood image
-FROM jesec/rtorrent:master as rtorrent
+FROM docker.io/jesec/rtorrent:master as rtorrent
 FROM flood as rtorrent-flood
 
 # Install rTorrent

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -1,5 +1,5 @@
 # Use node alpine docker image
-FROM node:alpine
+FROM docker.io/node:alpine
 
 ARG PACKAGE=flood
 ARG VERSION=latest

--- a/distribution/containers/Dockerfile.rtorrent
+++ b/distribution/containers/Dockerfile.rtorrent
@@ -1,9 +1,9 @@
 ARG FLOOD_VERSION=latest
 ARG RTORRENT_VERSION=latest
 
-FROM jesec/rtorrent:$RTORRENT_VERSION as rtorrent
+FROM docker.io/jesec/rtorrent:$RTORRENT_VERSION as rtorrent
 
-FROM jesec/flood:$FLOOD_VERSION as flood
+FROM docker.io/jesec/flood:$FLOOD_VERSION as flood
 
 # Install rTorrent
 COPY --from=rtorrent / /


### PR DESCRIPTION
This PR adds the container registry (docker.io) to image references. This enables out-of-the-box support for podman.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
