### PR TITLE
CI: add "jesec/flood:latest" tag to rolling release

### DIFF
--- a/.github/workflows/publish-rolling.yml
+++ b/.github/workflows/publish-rolling.yml
@@ -87,14 +87,16 @@ jobs:
         run: |
           echo ::set-output name=BUILD_VERSION::0.0.0-master.`git rev-parse --short HEAD`
 
-      - name: Publish flood:master to Docker Hub
+      - name: Publish flood to Docker Hub
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./distribution/containers/Dockerfile.release
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          tags: jesec/flood:master
+          tags: |
+            jesec/flood:master
+            jesec/flood:latest
           build-args: |
             PACKAGE=@jesec/flood
             VERSION=${{ steps.parse_version.outputs.BUILD_VERSION }}


### PR DESCRIPTION
## Description

Docker's default tag is "latest", so when not specifying a tag when pulling/pushing a tag from/to Docker Hub "latest" is used. The "latest" tag was used for "jesec/flood" previously but is not used anymore, leaving an outdated tag on Docker Hub. This outdated tag gets downloaded by default. This affects some of the docker-compose examples, too.

This PR adds the "latest" tag as a synonym for the "master" tag.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
