### PR TITLE
CI: make i18n sync workflow only run on main repo

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   synchronize-with-crowdin:
+    if: github.repository_owner == 'jesec'
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
## Description

The scheduled i18n sync workflow always fails on forks, this makes sure it is only run on jesec/flood.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
