### PR TITLE
Force new component instance when editing download rules and feeds

### DIFF
--- a/client/src/javascript/components/modals/feeds-modal/DownloadRulesTab.tsx
+++ b/client/src/javascript/components/modals/feeds-modal/DownloadRulesTab.tsx
@@ -198,6 +198,7 @@ const DownloadRulesTab: FC = () => {
       </FormRow>
       {isEditing ? (
         <DownloadRuleForm
+          key={currentRule?._id || 'initial'}
           rule={currentRule ?? initialRule}
           isPatternMatched={isPatternMatched}
           isSubmitting={isSubmitting}

--- a/client/src/javascript/components/modals/feeds-modal/FeedsTab.tsx
+++ b/client/src/javascript/components/modals/feeds-modal/FeedsTab.tsx
@@ -178,6 +178,7 @@ const FeedsTab: FC = () => {
           <FeedForm
             currentFeed={currentFeed}
             defaultFeed={defaultFeed}
+            key={currentFeed?._id || 'initial'}
             intervalMultipliers={INTERVAL_MULTIPLIERS}
             isSubmitting={isSubmitting}
             onCancel={() => {


### PR DESCRIPTION
## Description

Due to text inputs retaining their state on component rerenders
editing the download rules and feeds forces previous values to be bound
to the newly edited rule/feed.
A new component instance is forced by keying the parent component
and thus the new defaultValue on inputs is taken into account

## Related Issue

fixes #460

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)

## Comments

This is honestly a lazy fix, I think there could be other related issues to this due to the way `<form>` onSubmit is used and defaultValues on inputs to initialize them. Similar problems could arise anywhere else in the application where list-editing is handled in the same way, so I'd recommend a different aproach, but don't want to make too much of a mess.