### PR TITLE
Added filter by filesystem location + bonus tooltip on overflowed filter names

### DIFF
--- a/client/src/javascript/components/sidebar/LocationFilters.tsx
+++ b/client/src/javascript/components/sidebar/LocationFilters.tsx
@@ -1,0 +1,56 @@
+import {FC, KeyboardEvent, MouseEvent, ReactNode, TouchEvent} from 'react';
+import {observer} from 'mobx-react';
+import {useLingui} from '@lingui/react';
+import {LocationTreeNode} from '@shared/types/Taxonomy';
+
+import SidebarFilter from './SidebarFilter';
+import TorrentFilterStore from '../../stores/TorrentFilterStore';
+
+const LocationFilters: FC = observer(() => {
+  const {i18n} = useLingui();
+
+  const locations = Object.keys(TorrentFilterStore.taxonomy.locationCounts);
+
+  if (locations.length === 1 && locations[0] === '') {
+    return null;
+  }
+
+  const buildLocationFilterTree = (location: LocationTreeNode): ReactNode => {
+    if (location.children.length === 1 && TorrentFilterStore.taxonomy.locationCounts[location.fullPath] === TorrentFilterStore.taxonomy.locationCounts[location.children[0].fullPath]) {
+      const onlyChild = location.children[0];
+      const separator = onlyChild.fullPath.includes('/') ? '/' : '\\'
+      return buildLocationFilterTree({...onlyChild, directoryName: location.directoryName + separator + onlyChild.directoryName});
+    }
+
+    const children = location.children.map(buildLocationFilterTree);
+
+    return (
+      <SidebarFilter 
+        handleClick={(filter: string | '', event: KeyboardEvent | MouseEvent | TouchEvent) => TorrentFilterStore.setLocationFilters(filter, event)}
+        count={TorrentFilterStore.taxonomy.locationCounts[location.fullPath] || 0}
+        key={location.fullPath}
+        isActive={(location.fullPath === '' && !TorrentFilterStore.locationFilter.length) || TorrentFilterStore.locationFilter.includes(location.fullPath)}
+        name={location.directoryName}
+        slug={location.fullPath}
+        size={TorrentFilterStore.taxonomy.locationSizes[location.fullPath]}
+      >
+        {children.length && children || undefined}
+      </SidebarFilter>
+    );
+  };
+
+  const filterElements = TorrentFilterStore.taxonomy.locationTree.map(buildLocationFilterTree);
+
+  const title = i18n._('filter.location.title');
+
+  return (
+    <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
+      <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
+        {title}
+      </li>
+      {filterElements}
+    </ul>
+  );
+});
+
+export default LocationFilters;

--- a/client/src/javascript/components/sidebar/Sidebar.tsx
+++ b/client/src/javascript/components/sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import {OverlayScrollbarsComponent} from 'overlayscrollbars-react';
 import DiskUsage from './DiskUsage';
 import FeedsButton from './FeedsButton';
 import LogoutButton from './LogoutButton';
+import LocationFilters from './LocationFilters';
 import NotificationsButton from './NotificationsButton';
 import SearchBox from './SearchBox';
 import SettingsButton from './SettingsButton';
@@ -38,6 +39,7 @@ const Sidebar: FC = () => (
     <StatusFilters />
     <TagFilters />
     <TrackerFilters />
+    <LocationFilters />
     <DiskUsage />
     <div style={{flexGrow: 1}} />
     <SidebarActions>

--- a/client/src/javascript/components/sidebar/SidebarFilter.tsx
+++ b/client/src/javascript/components/sidebar/SidebarFilter.tsx
@@ -1,11 +1,13 @@
 import classnames from 'classnames';
-import {FC, ReactNode, KeyboardEvent, MouseEvent, TouchEvent} from 'react';
+import {FC, ReactNode, KeyboardEvent, MouseEvent, TouchEvent, useState} from 'react';
 import {useLingui} from '@lingui/react';
+import {Start} from '@client/ui/icons';
 
 import Badge from '../general/Badge';
 import Size from '../general/Size';
 
 interface SidebarFilterProps {
+  children?: ReactNode[];
   name: string;
   icon?: ReactNode;
   isActive: boolean;
@@ -16,6 +18,7 @@ interface SidebarFilterProps {
 }
 
 const SidebarFilter: FC<SidebarFilterProps> = ({
+  children,
   name: _name,
   icon,
   isActive,
@@ -26,9 +29,25 @@ const SidebarFilter: FC<SidebarFilterProps> = ({
 }: SidebarFilterProps) => {
   const {i18n} = useLingui();
 
+  const [expanded, setExpanded] = useState(false);
+
   const classNames = classnames('sidebar-filter__item', {
     'is-active': isActive,
   });
+  const expanderClassNames = classnames('sidebar-filter__expander', {
+    'is-active': isActive,
+    'expanded': expanded,
+  })
+
+  const flexCss = children ? {
+    display: 'flex',
+  }: {};
+  const focusCss = {
+    ':focus': {
+      outline: 'none',
+      WebkitTapHighlightColor: 'transparent',
+    },
+  };
 
   let name = _name;
   if (name === '') {
@@ -46,25 +65,55 @@ const SidebarFilter: FC<SidebarFilterProps> = ({
     }
   }
 
+  const setTitleForOverflowedName = (event: MouseEvent) => {
+    const target = event.target as HTMLSpanElement;
+    const overflowed = target.scrollWidth > target.clientWidth;
+    target.title = overflowed ? target.textContent || '' : '';
+  }
+
+  const unsetTitle = (event: MouseEvent) => {
+    const target = event.target as HTMLSpanElement;
+    target.title = '';
+  }
+
   return (
     <li>
-      <button
-        className={classNames}
-        css={{
-          ':focus': {
-            outline: 'none',
-            WebkitTapHighlightColor: 'transparent',
-          },
-        }}
-        type="button"
-        onClick={(event) => handleClick(slug, event)}
-        role="menuitem"
-      >
-        {icon}
-        <span className="name">{name}</span>
-        <Badge>{count}</Badge>
-        {size && <Size value={size} className="size" />}
-      </button>
+      <div css={flexCss}>
+        {children &&
+        <button
+          className={expanderClassNames}
+          css={focusCss}
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          role="switch"
+          aria-checked={expanded}
+        >
+          <Start />
+        </button>
+        }
+        <button
+          className={classNames}
+          css={focusCss}
+          type="button"
+          onClick={(event) => handleClick(slug, event)}
+          role="menuitem"
+        >
+          {icon}
+          <span
+            className="name"
+            onMouseOver={setTitleForOverflowedName}
+            onMouseOut={unsetTitle}
+          >
+            {name}
+          </span>
+          <Badge>{count}</Badge>
+          {size && <Size value={size} className="size" />}
+        </button>
+      </div>
+      {children && expanded &&
+      <ul className="sidebar-filter__nested">
+        {children}
+      </ul>}
     </li>
   );
 };

--- a/client/src/javascript/i18n/strings/en.json
+++ b/client/src/javascript/i18n/strings/en.json
@@ -139,6 +139,7 @@
   "filter.status.seeding": "Seeding",
   "filter.status.stopped": "Stopped",
   "filter.status.title": "Filter by Status",
+  "filter.location.title": "Filter by Location",
   "filter.tag.title": "Filter by Tag",
   "filter.tracker.title": "Filter by Tracker",
   "filter.untagged": "Untagged",

--- a/client/src/javascript/stores/TorrentFilterStore.ts
+++ b/client/src/javascript/stores/TorrentFilterStore.ts
@@ -6,6 +6,7 @@ import type {Taxonomy} from '@shared/types/Taxonomy';
 import torrentStatusMap, {TorrentStatus} from '@shared/constants/torrentStatusMap';
 
 class TorrentFilterStore {
+  locationFilter: Array<string> = [];
   searchFilter = '';
   statusFilter: Array<TorrentStatus> = [];
   tagFilter: Array<string> = [];
@@ -14,6 +15,9 @@ class TorrentFilterStore {
   filterTrigger = false;
 
   taxonomy: Taxonomy = {
+    locationCounts: {},
+    locationSizes: {},
+    locationTree: [],
     statusCounts: {},
     tagCounts: {},
     tagSizes: {},
@@ -22,7 +26,7 @@ class TorrentFilterStore {
   };
 
   @computed get isFilterActive() {
-    return this.searchFilter !== '' || this.statusFilter.length || this.tagFilter.length || this.trackerFilter.length;
+    return this.locationFilter.length || this.searchFilter !== '' || this.statusFilter.length || this.tagFilter.length || this.trackerFilter.length;
   }
 
   constructor() {
@@ -30,6 +34,7 @@ class TorrentFilterStore {
   }
 
   clearAllFilters() {
+    this.locationFilter = [];
     this.searchFilter = '';
     this.statusFilter = [];
     this.tagFilter = [];
@@ -47,6 +52,13 @@ class TorrentFilterStore {
 
   setSearchFilter(filter: string) {
     this.searchFilter = filter;
+    this.filterTrigger = !this.filterTrigger;
+  }
+
+  setLocationFilters(filter: string | '', event: KeyboardEvent | MouseEvent | TouchEvent) {
+    const locations = Object.keys(this.taxonomy.locationCounts).sort((a, b) => a.localeCompare(b));
+
+    this.computeFilters(locations, this.locationFilter, filter, event);
     this.filterTrigger = !this.filterTrigger;
   }
 

--- a/client/src/javascript/stores/TorrentStore.ts
+++ b/client/src/javascript/stores/TorrentStore.ts
@@ -24,9 +24,16 @@ class TorrentStore {
   }
 
   @computed get filteredTorrents(): Array<TorrentProperties> {
-    const {searchFilter, statusFilter, tagFilter, trackerFilter} = TorrentFilterStore;
+    const {locationFilter, searchFilter, statusFilter, tagFilter, trackerFilter} = TorrentFilterStore;
 
     let filteredTorrents = Object.assign([], this.sortedTorrents) as Array<TorrentProperties>;
+
+    if (locationFilter.length) {
+      filteredTorrents = filterTorrents(filteredTorrents, {
+        type: 'location',
+        filter: locationFilter,
+      });
+    }
 
     if (searchFilter !== '') {
       filteredTorrents = termMatch(filteredTorrents, (properties) => properties.name, searchFilter);

--- a/client/src/javascript/util/filterTorrents.ts
+++ b/client/src/javascript/util/filterTorrents.ts
@@ -1,6 +1,11 @@
 import type {TorrentProperties} from '@shared/types/Torrent';
 import type {TorrentStatus} from '@shared/constants/torrentStatusMap';
 
+interface LocationFilter {
+  type: 'location';
+  filter: string[];
+}
+
 interface StatusFilter {
   type: 'status';
   filter: TorrentStatus[];
@@ -18,9 +23,13 @@ interface TagFilter {
 
 function filterTorrents(
   torrentList: TorrentProperties[],
-  opts: StatusFilter | TrackerFilter | TagFilter,
+  opts: LocationFilter | StatusFilter | TrackerFilter | TagFilter,
 ): TorrentProperties[] {
   if (opts.filter.length) {
+    if (opts.type === 'location') {
+      return torrentList.filter((torrent) => opts.filter.some((directory) => torrent.directory.startsWith(directory)));
+    }
+
     if (opts.type === 'status') {
       return torrentList.filter((torrent) => torrent.status.some((status) => opts.filter.includes(status)));
     }

--- a/client/src/sass/components/_sidebar-filter.scss
+++ b/client/src/sass/components/_sidebar-filter.scss
@@ -8,6 +8,7 @@
     padding-top: 0;
   }
 
+  &__expander,
   &__item {
     @include themes.theme('color', 'sidebar-filter--foreground');
     cursor: pointer;
@@ -75,7 +76,22 @@
 
     .size {
       margin-left: auto;
+      white-space: nowrap;
     }
+  }
+
+  &__expander {
+    display: block;
+    width: 14px;
+    padding: 0 0 0 20px;
+
+    &.expanded svg {
+      transform: rotate(90deg);
+    }
+  }
+
+  &__nested {
+    margin-left: 8px;
   }
 
   .badge {

--- a/server/services/taxonomyService.ts
+++ b/server/services/taxonomyService.ts
@@ -3,7 +3,7 @@ import jsonpatch, {Operation} from 'fast-json-patch';
 import BaseService from './BaseService';
 import torrentStatusMap from '../../shared/constants/torrentStatusMap';
 
-import type {Taxonomy} from '../../shared/types/Taxonomy';
+import type {Taxonomy, LocationTreeNode} from '../../shared/types/Taxonomy';
 import type {TorrentStatus} from '../../shared/constants/torrentStatusMap';
 import type {TorrentProperties, TorrentList} from '../../shared/types/Torrent';
 
@@ -13,6 +13,9 @@ interface TaxonomyServiceEvents {
 
 class TaxonomyService extends BaseService<TaxonomyServiceEvents> {
   taxonomy: Taxonomy = {
+    locationCounts: { '': 0 },
+    locationSizes: {},
+    locationTree: [],
     statusCounts: {'': 0},
     tagCounts: {'': 0, untagged: 0},
     tagSizes: {},
@@ -61,6 +64,9 @@ class TaxonomyService extends BaseService<TaxonomyServiceEvents> {
 
   handleProcessTorrentListStart = () => {
     this.lastTaxonomy = {
+      locationCounts: {...this.taxonomy.locationCounts},
+      locationSizes: {...this.taxonomy.locationCounts},
+      locationTree: [...this.taxonomy.locationTree],
       statusCounts: {...this.taxonomy.statusCounts},
       tagCounts: {...this.taxonomy.tagCounts},
       tagSizes: {...this.taxonomy.tagSizes},
@@ -72,6 +78,9 @@ class TaxonomyService extends BaseService<TaxonomyServiceEvents> {
       this.taxonomy.statusCounts[status] = 0;
     });
 
+    this.taxonomy.locationCounts = {'': 0};
+    this.taxonomy.locationSizes = {};
+    this.taxonomy.locationTree = []
     this.taxonomy.statusCounts[''] = 0;
     this.taxonomy.tagCounts = {'': 0, untagged: 0};
     this.taxonomy.tagSizes = {};
@@ -79,9 +88,58 @@ class TaxonomyService extends BaseService<TaxonomyServiceEvents> {
     this.taxonomy.trackerSizes = {};
   };
 
-  handleProcessTorrentListEnd = ({torrents}: {torrents: TorrentList}) => {
-    const {length} = Object.keys(torrents);
+  buildLocationTree = () => {
+    const locations = Object.keys(this.taxonomy.locationCounts);
+    const sortedLocations = locations.slice().sort((a, b) => {
+      if (a === '') {
+        return -1;
+      }
+      if (b === '') {
+        return 1;
+      }
 
+      // Order slashes before similar paths with different symbols, eg. /files/PC/ should come before /files/PC-98/ for treeing
+      return a.replace(/[^\\/\w]/g, "~").localeCompare(b.replace(/[^\\/\w]/g, "~"));
+    });
+
+    const separator = sortedLocations.length < 2 || sortedLocations[1].includes('/') ? '/' : '\\';
+    let previousLocation: LocationTreeNode;
+    this.taxonomy.locationTree = sortedLocations.reduce((tree, filter) => {
+      const directory = filter.split(separator).slice(-1)[0];
+      const parentPath = filter.substring(0, filter.lastIndexOf(separator + directory))
+      const location: LocationTreeNode = { directoryName: directory, fullPath: filter, children: [] };
+      while (previousLocation) { // Move up the tree to a matching parent
+        if (!previousLocation.parent || previousLocation.fullPath === parentPath) {
+          break;
+        }
+        previousLocation = previousLocation.parent;
+      }
+      if (previousLocation && previousLocation.fullPath === parentPath && parentPath !== '') { // Child
+        location.parent = previousLocation;
+        previousLocation.children.push(location);
+      } else if (previousLocation && previousLocation.parent && previousLocation.parent.fullPath === parentPath) { // Sibling
+        location.parent = previousLocation.parent;
+        previousLocation.parent.children.push(location);
+      } else { // Root
+        tree.push(location);
+      }
+      previousLocation = location;
+      return tree;
+    }, [] as LocationTreeNode[]);
+  }
+
+  cleanLocationTree = (location: LocationTreeNode) => {
+    location.parent = undefined;
+    location.children.forEach(this.cleanLocationTree);
+  }
+
+  handleProcessTorrentListEnd = ({ torrents }: { torrents: TorrentList }) => {
+    const { length } = Object.keys(torrents);
+
+    this.buildLocationTree();
+    this.taxonomy.locationTree.forEach(this.cleanLocationTree);
+
+    this.taxonomy.locationCounts[''] = length;
     this.taxonomy.statusCounts[''] = length;
     this.taxonomy.tagCounts[''] = length;
     this.taxonomy.trackerCounts[''] = length;
@@ -97,12 +155,44 @@ class TaxonomyService extends BaseService<TaxonomyServiceEvents> {
   };
 
   handleProcessTorrent = (torrentProperties: TorrentProperties) => {
+    this.incrementLocationCountsAndSizes(torrentProperties.directory, torrentProperties.sizeBytes);
     this.incrementStatusCounts(torrentProperties.status);
     this.incrementTagCounts(torrentProperties.tags);
     this.incrementTagSizes(torrentProperties.tags, torrentProperties.sizeBytes);
     this.incrementTrackerCounts(torrentProperties.trackerURIs);
     this.incrementTrackerSizes(torrentProperties.trackerURIs, torrentProperties.sizeBytes);
   };
+
+  incrementLocationCountsAndSizes(directory: TorrentProperties['directory'], sizeBytes: TorrentProperties['sizeBytes']) {
+    const separator = directory.includes('/') ? '/' : '\\';
+    const parts = directory.startsWith(separator) ? directory.split(separator).slice(1) : directory.split(separator);
+    let heirarchy = '';
+
+    if (this.taxonomy.locationCounts[heirarchy] != null) {
+      this.taxonomy.locationCounts[heirarchy] += 1;
+    } else {
+      this.taxonomy.locationCounts[heirarchy] = 1;
+    }
+    if (this.taxonomy.locationSizes[heirarchy] != null) {
+      this.taxonomy.locationSizes[heirarchy] += sizeBytes;
+    } else {
+      this.taxonomy.locationSizes[heirarchy] = sizeBytes;
+    }
+
+    parts.forEach((part) => {
+      heirarchy += separator + part;
+      if (this.taxonomy.locationCounts[heirarchy] != null) {
+        this.taxonomy.locationCounts[heirarchy] += 1;
+      } else {
+        this.taxonomy.locationCounts[heirarchy] = 1;
+      }
+      if (this.taxonomy.locationSizes[heirarchy] != null) {
+        this.taxonomy.locationSizes[heirarchy] += sizeBytes;
+      } else {
+        this.taxonomy.locationSizes[heirarchy] = sizeBytes;
+      }
+    });
+  }
 
   incrementStatusCounts(statuses: Array<TorrentStatus>) {
     statuses.forEach((status) => {

--- a/shared/types/Taxonomy.ts
+++ b/shared/types/Taxonomy.ts
@@ -1,4 +1,14 @@
+export interface LocationTreeNode {
+  directoryName: string;
+  fullPath: string;
+  children: LocationTreeNode[];
+  parent?: LocationTreeNode;
+};
+
 export interface Taxonomy {
+  locationCounts: Record<string, number>;
+  locationSizes: Record<string, number>;
+  locationTree: LocationTreeNode[];
   statusCounts: Record<string, number>;
   tagCounts: Record<string, number>;
   tagSizes: Record<string, number>;


### PR DESCRIPTION
New filter section that allows viewing space usage/torrent count by directory in tree format.
Filter names overflow with ellipses, and in the case of root directories, this is common: so I added a title-based tooltip to filter elements where the text is overflowed. Only appears on overflowed elements, and on mouse event. Not sure if equivalent touch events would work the same way.

No issue submitted, just something I wanted to make.

![image](https://user-images.githubusercontent.com/677609/154831440-0bb7f2ff-1df1-49e3-ac40-edde897babd2.png)
![image](https://user-images.githubusercontent.com/677609/154831523-80361b4f-9ccb-4208-b819-eba88c643db5.png)

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
