### PR TITLE
Make sidebar filter sections collapseable

### DIFF
--- a/client/src/javascript/components/sidebar/Expando.tsx
+++ b/client/src/javascript/components/sidebar/Expando.tsx
@@ -3,15 +3,20 @@ import {Chevron} from '@client/ui/icons';
 
 interface ExpandoProps {
   children: ReactNode;
+  className?: string;
   expanded: boolean;
   handleClick: (event: KeyboardEvent | MouseEvent | TouchEvent) => void;
 }
 
-const Expando: FC<ExpandoProps> = ({children, expanded, handleClick}: ExpandoProps) => (
-  <button className="expando" onClick={(event) => handleClick(event)} css={{textTransform: "inherit", display:"flex", alignItems: "center"}}>
+const Expando: FC<ExpandoProps> = ({children, className, expanded, handleClick}: ExpandoProps) => (
+  <button className={className} onClick={(event) => handleClick(event)}>
     {children}
     {expanded ? <Chevron css={{transform:"scaleY(-1)"}} /> : <Chevron />}
   </button>
 );
+
+Expando.defaultProps = {
+  className: undefined,
+};
 
 export default Expando;

--- a/client/src/javascript/components/sidebar/Expando.tsx
+++ b/client/src/javascript/components/sidebar/Expando.tsx
@@ -1,0 +1,17 @@
+import {FC, KeyboardEvent, MouseEvent, ReactNode, TouchEvent} from 'react';
+import {Chevron} from '@client/ui/icons';
+
+interface ExpandoProps {
+  children: ReactNode;
+  expanded: boolean;
+  handleClick: (event: KeyboardEvent | MouseEvent | TouchEvent) => void;
+}
+
+const Expando: FC<ExpandoProps> = ({children, expanded, handleClick}: ExpandoProps) => (
+  <button className="expando" onClick={(event) => handleClick(event)} css={{textTransform: "inherit", display:"flex", alignItems: "center"}}>
+    {children}
+    {expanded ? <Chevron css={{transform:"scaleY(-1)"}} /> : <Chevron />}
+  </button>
+);
+
+export default Expando;

--- a/client/src/javascript/components/sidebar/Expando.tsx
+++ b/client/src/javascript/components/sidebar/Expando.tsx
@@ -11,7 +11,7 @@ interface ExpandoProps {
 const Expando: FC<ExpandoProps> = ({children, className, expanded, handleClick}: ExpandoProps) => (
   <button className={className} onClick={(event) => handleClick(event)}>
     {children}
-    {expanded ? <Chevron css={{transform:"scaleY(-1)"}} /> : <Chevron />}
+    {expanded ? <Chevron css={{transform: 'scaleY(-1)'}} /> : <Chevron />}
   </button>
 );
 

--- a/client/src/javascript/components/sidebar/StatusFilters.tsx
+++ b/client/src/javascript/components/sidebar/StatusFilters.tsx
@@ -85,7 +85,7 @@ const StatusFilters: FC = observer(() => {
   const [expanded, setExpanded] = useState<boolean>(true);
   const expandoClick = () => {
     setExpanded(!expanded);
-  }
+  };
 
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">

--- a/client/src/javascript/components/sidebar/StatusFilters.tsx
+++ b/client/src/javascript/components/sidebar/StatusFilters.tsx
@@ -1,4 +1,4 @@
-import {FC} from 'react';
+import {FC, useState} from 'react';
 import {observer} from 'mobx-react';
 import {useLingui} from '@lingui/react';
 
@@ -8,6 +8,7 @@ import TorrentFilterStore from '@client/stores/TorrentFilterStore';
 import type {TorrentStatus} from '@shared/constants/torrentStatusMap';
 
 import SidebarFilter from './SidebarFilter';
+import Expando from './Expando';
 
 const StatusFilters: FC = observer(() => {
   const {i18n} = useLingui();
@@ -81,12 +82,19 @@ const StatusFilters: FC = observer(() => {
 
   const title = i18n._('filter.status.title');
 
+  const [expanded, setExpanded] = useState<boolean>(true);
+  const expandoClick = () => {
+    setExpanded(!expanded);
+  }
+
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
       <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
+        <Expando expanded={expanded} handleClick={expandoClick}>
         {title}
+        </Expando>
       </li>
-      {filterElements}
+      {expanded && filterElements}
     </ul>
   );
 });

--- a/client/src/javascript/components/sidebar/StatusFilters.tsx
+++ b/client/src/javascript/components/sidebar/StatusFilters.tsx
@@ -90,8 +90,8 @@ const StatusFilters: FC = observer(() => {
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
       <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
-        <Expando expanded={expanded} handleClick={expandoClick}>
-        {title}
+        <Expando className="sidebar-filter__item--expando" expanded={expanded} handleClick={expandoClick}>
+          {title}
         </Expando>
       </li>
       {expanded && filterElements}

--- a/client/src/javascript/components/sidebar/StatusFilters.tsx
+++ b/client/src/javascript/components/sidebar/StatusFilters.tsx
@@ -89,8 +89,8 @@ const StatusFilters: FC = observer(() => {
 
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
-      <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
-        <Expando className="sidebar-filter__item--expando" expanded={expanded} handleClick={expandoClick}>
+      <li className="sidebar-filter__item" role="none">
+        <Expando className="sidebar-filter__item--heading" expanded={expanded} handleClick={expandoClick}>
           {title}
         </Expando>
       </li>

--- a/client/src/javascript/components/sidebar/TagFilters.tsx
+++ b/client/src/javascript/components/sidebar/TagFilters.tsx
@@ -1,8 +1,9 @@
-import {FC} from 'react';
+import {FC, useState} from 'react';
 import {observer} from 'mobx-react';
 import {useLingui} from '@lingui/react';
 
 import SidebarFilter from './SidebarFilter';
+import Expando from './Expando';
 import TorrentFilterStore from '../../stores/TorrentFilterStore';
 
 const TagFilters: FC = observer(() => {
@@ -42,12 +43,19 @@ const TagFilters: FC = observer(() => {
 
   const title = i18n._('filter.tag.title');
 
+  const [expanded, setExpanded] = useState<boolean>(true);
+  const expandoClick = () => {
+    setExpanded(!expanded);
+  }
+
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
       <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
+        <Expando expanded={expanded} handleClick={expandoClick}>
         {title}
+        </Expando>
       </li>
-      {filterElements}
+      {expanded && filterElements}
     </ul>
   );
 });

--- a/client/src/javascript/components/sidebar/TagFilters.tsx
+++ b/client/src/javascript/components/sidebar/TagFilters.tsx
@@ -50,8 +50,8 @@ const TagFilters: FC = observer(() => {
 
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
-      <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
-        <Expando className="sidebar-filter__item--expando" expanded={expanded} handleClick={expandoClick}>
+      <li className="sidebar-filter__item" role="none">
+        <Expando className="sidebar-filter__item--heading" expanded={expanded} handleClick={expandoClick}>
           {title}
         </Expando>
       </li>

--- a/client/src/javascript/components/sidebar/TagFilters.tsx
+++ b/client/src/javascript/components/sidebar/TagFilters.tsx
@@ -51,8 +51,8 @@ const TagFilters: FC = observer(() => {
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
       <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
-        <Expando expanded={expanded} handleClick={expandoClick}>
-        {title}
+        <Expando className="sidebar-filter__item--expando" expanded={expanded} handleClick={expandoClick}>
+          {title}
         </Expando>
       </li>
       {expanded && filterElements}

--- a/client/src/javascript/components/sidebar/TagFilters.tsx
+++ b/client/src/javascript/components/sidebar/TagFilters.tsx
@@ -46,7 +46,7 @@ const TagFilters: FC = observer(() => {
   const [expanded, setExpanded] = useState<boolean>(true);
   const expandoClick = () => {
     setExpanded(!expanded);
-  }
+  };
 
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">

--- a/client/src/javascript/components/sidebar/TrackerFilters.tsx
+++ b/client/src/javascript/components/sidebar/TrackerFilters.tsx
@@ -45,7 +45,7 @@ const TrackerFilters: FC = observer(() => {
   const [expanded, setExpanded] = useState<boolean>(true);
   const expandoClick = () => {
     setExpanded(!expanded);
-  }
+  };
 
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">

--- a/client/src/javascript/components/sidebar/TrackerFilters.tsx
+++ b/client/src/javascript/components/sidebar/TrackerFilters.tsx
@@ -49,8 +49,8 @@ const TrackerFilters: FC = observer(() => {
 
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
-      <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
-        <Expando className="sidebar-filter__item--expando" expanded={expanded} handleClick={expandoClick}>
+      <li className="sidebar-filter__item" role="none">
+        <Expando className="sidebar-filter__item--heading" expanded={expanded} handleClick={expandoClick}>
           {title}
         </Expando>
       </li>

--- a/client/src/javascript/components/sidebar/TrackerFilters.tsx
+++ b/client/src/javascript/components/sidebar/TrackerFilters.tsx
@@ -50,8 +50,8 @@ const TrackerFilters: FC = observer(() => {
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
       <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
-        <Expando expanded={expanded} handleClick={expandoClick}>
-        {title}
+        <Expando className="sidebar-filter__item--expando" expanded={expanded} handleClick={expandoClick}>
+          {title}
         </Expando>
       </li>
       {expanded && filterElements}

--- a/client/src/javascript/components/sidebar/TrackerFilters.tsx
+++ b/client/src/javascript/components/sidebar/TrackerFilters.tsx
@@ -1,8 +1,9 @@
-import {FC} from 'react';
+import {FC, useState} from 'react';
 import {observer} from 'mobx-react';
 import {useLingui} from '@lingui/react';
 
 import SidebarFilter from './SidebarFilter';
+import Expando from './Expando';
 import TorrentFilterStore from '../../stores/TorrentFilterStore';
 
 const TrackerFilters: FC = observer(() => {
@@ -41,12 +42,19 @@ const TrackerFilters: FC = observer(() => {
 
   const title = i18n._('filter.tracker.title');
 
+  const [expanded, setExpanded] = useState<boolean>(true);
+  const expandoClick = () => {
+    setExpanded(!expanded);
+  }
+
   return (
     <ul aria-label={title} className="sidebar-filter sidebar__item" role="menu">
       <li className="sidebar-filter__item sidebar-filter__item--heading" role="none">
+        <Expando expanded={expanded} handleClick={expandoClick}>
         {title}
+        </Expando>
       </li>
-      {filterElements}
+      {expanded && filterElements}
     </ul>
   );
 });

--- a/client/src/sass/components/_sidebar-filter.scss
+++ b/client/src/sass/components/_sidebar-filter.scss
@@ -42,7 +42,7 @@
       }
     }
 
-    &--expando {
+    &--heading {
       cursor: default;
       font-size: 0.8em;
       font-weight: 500;

--- a/client/src/sass/components/_sidebar-filter.scss
+++ b/client/src/sass/components/_sidebar-filter.scss
@@ -42,7 +42,7 @@
       }
     }
 
-    &--heading {
+    &--expando {
       cursor: default;
       font-size: 0.8em;
       font-weight: 500;


### PR DESCRIPTION
Makes sidebar filter sections collapseable by clicking the title. Since filter lists can get quite long, scrolling down to the tracker list or whichever can be tedious. Simple chevron/carat indicator hides filter section children.

![image](https://user-images.githubusercontent.com/677609/154831997-f5491a30-8390-452a-abb9-b00859c14f91.png)

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
