### PR TITLE
Fix regression introduced in PR #519, fixes #522

### DIFF
--- a/client/src/javascript/components/sidebar/TagFilters.tsx
+++ b/client/src/javascript/components/sidebar/TagFilters.tsx
@@ -8,6 +8,7 @@ import TorrentFilterStore from '../../stores/TorrentFilterStore';
 
 const TagFilters: FC = observer(() => {
   const {i18n} = useLingui();
+  const [expanded, setExpanded] = useState<boolean>(true);
 
   const tags = Object.keys(TorrentFilterStore.taxonomy.tagCounts);
 
@@ -43,7 +44,6 @@ const TagFilters: FC = observer(() => {
 
   const title = i18n._('filter.tag.title');
 
-  const [expanded, setExpanded] = useState<boolean>(true);
   const expandoClick = () => {
     setExpanded(!expanded);
   };

--- a/client/src/javascript/components/sidebar/TrackerFilters.tsx
+++ b/client/src/javascript/components/sidebar/TrackerFilters.tsx
@@ -8,6 +8,7 @@ import TorrentFilterStore from '../../stores/TorrentFilterStore';
 
 const TrackerFilters: FC = observer(() => {
   const {i18n} = useLingui();
+  const [expanded, setExpanded] = useState<boolean>(true);
 
   const trackers = Object.keys(TorrentFilterStore.taxonomy.trackerCounts);
 
@@ -42,7 +43,6 @@ const TrackerFilters: FC = observer(() => {
 
   const title = i18n._('filter.tracker.title');
 
-  const [expanded, setExpanded] = useState<boolean>(true);
   const expandoClick = () => {
     setExpanded(!expanded);
   };


### PR DESCRIPTION

Fixes regression introduced in #519 that prevented to reach the overview page when no torrent was present.

<!--- Describe your changes in detail -->
The changes are simply to make sur that the expand status hooks are defined before the related components can be returned.

## Related Issue

#519 

## Screenshots

## Types of changes

Fix is for a change that is not yest part of a release

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
