### PR TITLE
Directly add torrents when paste valid magnet urls

### DIFF
--- a/shared/util/regEx.ts
+++ b/shared/util/regEx.ts
@@ -1,3 +1,4 @@
 export const url = /^(?:https?|ftp):\/\/.{1,}\.{1}.{1,}/;
+export const magnet = /^magnet:\?xt=urn:[a-z0-9]+:[a-z0-9]{32,40}&dn=.+&tr=.+$/;
 export const cdata = /<!\[CDATA\[(.*?)\]\]>/;
 export const noComma = /^[^,]+$/;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When you paste a valid magnet URL it will add the torrents directly.

It will capture all valid magnet urls from the pasted content (I'm using [this regex](https://github.com/tiaanduplessis/magnet-link-regex/blob/master/index.js)), and add then all.

<!--- Describe your changes in detail -->

<!--- Optional -->

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
