### PR TITLE
Fix torrent download extension override

### DIFF
--- a/client/src/javascript/components/general/filesystem/DirectoryFileList.tsx
+++ b/client/src/javascript/components/general/filesystem/DirectoryFileList.tsx
@@ -65,7 +65,7 @@ const DirectoryFiles: FC<DirectoryFilesProps> = ({depth, items, hash, path, onIt
             <div className="file__name">
               {/* TODO: Add a WebAssembly decoding player if the feature is popular */}
               <a
-                href={`${ConfigStore.baseURI}api/torrents/${hash}/contents/${file.index}/data`}
+                href={`${ConfigStore.baseURI}api/torrents/${hash}/contents/${file.index}/data?streaming`}
                 style={{textDecoration: 'none'}}
                 target="_blank"
                 rel="noreferrer"

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentContents.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentContents.tsx
@@ -143,29 +143,17 @@ const TorrentContents: FC = observer(() => {
               }}
             />
           </FormRowItem>
-          <Button
-            onClick={(event) => {
-              event.preventDefault();
-              const {baseURI} = ConfigStore;
-              const link = document.createElement('a');
-
-              link.download = '';
-              link.href = `${baseURI}api/torrents/${hash}/contents/${selectedIndices.join(',')}/data`;
-              link.style.display = 'none';
-
-              document.body.appendChild(link);
-              link.click();
-              document.body.removeChild(link);
-            }}
-            grow={false}
-            shrink={false}
-          >
-            <Trans
-              id="torrents.details.files.download.file"
-              values={{
-                count: selectedIndices.length,
-              }}
-            />
+          <Button>
+            <a
+              href={`${ConfigStore.baseURI}api/torrents/${hash}/contents/${selectedIndices.join(',')}/data`}
+              style={{textDecoration: 'none'}}
+              download
+            >
+              <Trans
+                id="torrents.details.files.download.file"
+                values={{count: selectedIndices.length}}
+              />
+            </a>
           </Button>
           <Select id="file-priority" persistentPlaceholder shrink={false} defaultID="">
             <SelectItem id={-1} isPlaceholder>

--- a/server/routes/api/torrents.ts
+++ b/server/routes/api/torrents.ts
@@ -706,17 +706,14 @@ router.get<{hash: string; indices: string}, unknown, unknown, {token: string}>(
     const {hash, indices: stringIndices} = req.params;
 
     if (req.user != null && req.query.token == null) {
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1689018
-      if (req.headers?.['user-agent']?.includes('Firefox/') !== true) {
-        res.redirect(
-          `?token=${getToken<ContentToken>({
-            username: req.user.username,
-            hash,
-            indices: stringIndices,
-          })}`,
-        );
-        return res;
-      }
+      res.redirect(
+        `?token=${getToken<ContentToken>({
+          username: req.user.username,
+          hash,
+          indices: stringIndices,
+        })}`,
+      );
+      return res;
     }
 
     const selectedTorrent = req.services.torrentService.getTorrent(hash);


### PR DESCRIPTION
## Description

When downloading a single mkv file, Flood is changing its content-type to webm, and it makes Firefox change the file extension to .webm, which is annoying.
This PR fixes that by making the content-type override opt-in and only enabled in the file preview links.

I'd also like to add direct download links to the torrent files modal, next to the clipboard icon (or the reverse, make the file link a download and add a preview button). This would be useful when a torrent contains a few files that can be downloaded manually instead of going through the tar export. What do you think ?

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
