### PR TITLE
Added comment to torrent details

### DIFF
--- a/client/src/javascript/components/general/LinkedText.tsx
+++ b/client/src/javascript/components/general/LinkedText.tsx
@@ -1,0 +1,38 @@
+import {FC} from 'react';
+
+interface LinkedTextProps {
+  text: string;
+  className?: string;
+}
+
+function isValidHttpUrl(s: string) {
+  var url;
+
+  try {
+    url = new URL(s);
+  } catch (_) {
+    return false;
+  }
+
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+const LinkedText: FC<LinkedTextProps> = ({text, className}: LinkedTextProps) => {
+  const nodes = text.split(/(?<=\s)(?!\s)(?:\b|\B)/).map((s) =>
+    isValidHttpUrl(s.trimEnd()) ? (
+      <a href={s.trimEnd()} target="_blank">
+        {s}
+      </a>
+    ) : (
+      s
+    ),
+  );
+
+  return <span className={className}>{nodes}</span>;
+};
+
+LinkedText.defaultProps = {
+  className: undefined,
+};
+
+export default LinkedText;

--- a/client/src/javascript/components/general/LinkedText.tsx
+++ b/client/src/javascript/components/general/LinkedText.tsx
@@ -6,7 +6,7 @@ interface LinkedTextProps {
 }
 
 function isValidHttpUrl(s: string) {
-  var url;
+  let url;
 
   try {
     url = new URL(s);
@@ -20,7 +20,7 @@ function isValidHttpUrl(s: string) {
 const LinkedText: FC<LinkedTextProps> = ({text, className}: LinkedTextProps) => {
   const nodes = text.split(/(?<=\s)(?!\s)(?:\b|\B)/).map((s) =>
     isValidHttpUrl(s.trimEnd()) ? (
-      <a href={s.trimEnd()} target="_blank">
+      <a href={s.trimEnd()} target="_blank" rel="noopener noreferrer">
         {s}
       </a>
     ) : (

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentGeneralInfo.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentGeneralInfo.tsx
@@ -4,6 +4,7 @@ import {Trans, useLingui} from '@lingui/react';
 
 import type {TorrentProperties} from '@shared/types/Torrent';
 
+import LinkedText from '../../general/LinkedText';
 import Size from '../../general/Size';
 import TorrentStore from '../../../stores/TorrentStore';
 import UIStore from '../../../stores/UIStore';
@@ -199,6 +200,14 @@ const TorrentGeneralInfo: FC = observer(() => {
               {torrent.isPrivate
                 ? i18n._('torrents.details.general.type.private')
                 : i18n._('torrents.details.general.type.public')}
+            </td>
+          </tr>
+          <tr className="torrent-details__detail torrent-details__detail--comment">
+            <td className="torrent-details__detail__label">
+              <Trans id="torrents.details.general.comment" />
+            </td>
+            <td className="torrent-details_detail__value">
+              <LinkedText text={torrent.comment} />
             </td>
           </tr>
           <tr className="torrent-details__table__heading">

--- a/server/services/Deluge/clientGatewayService.ts
+++ b/server/services/Deluge/clientGatewayService.ts
@@ -284,6 +284,7 @@ class DelugeClientGatewayService extends ClientGatewayService {
     return this.clientRequestManager
       .coreGetTorrentsStatus([
         'active_time',
+        'comment',
         'download_location',
         'download_payload_rate',
         'eta',
@@ -322,6 +323,7 @@ class DelugeClientGatewayService extends ClientGatewayService {
 
               const torrentProperties: TorrentProperties = {
                 bytesDone: status.total_done,
+                comment: status.comment,
                 dateActive:
                   status.download_payload_rate > 0 || status.upload_payload_rate > 0 ? -1 : status.active_time,
                 dateAdded: status.time_added,

--- a/server/services/Deluge/types/DelugeCoreMethods.ts
+++ b/server/services/Deluge/types/DelugeCoreMethods.ts
@@ -151,7 +151,7 @@ export interface DelugeCoreTorrentStatuses {
   trackers: Array<DelugeCoreTorrentTrackerStatuses>;
   tracker_status: unknown;
   upload_payload_rate: number;
-  comment: unknown;
+  comment: string;
   creator: unknown;
   num_files: unknown;
   num_pieces: unknown;

--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -353,6 +353,7 @@ class TransmissionClientGatewayService extends ClientGatewayService {
         'hashString',
         'downloadDir',
         'name',
+        'comment',
         'haveValid',
         'addedDate',
         'dateCreated',
@@ -389,6 +390,7 @@ class TransmissionClientGatewayService extends ClientGatewayService {
               const torrentProperties: TorrentProperties = {
                 hash: torrent.hashString.toUpperCase(),
                 name: torrent.name,
+                comment: torrent.comment,
                 bytesDone: torrent.haveValid,
                 dateActive: torrent.rateDownload > 0 || torrent.rateUpload > 0 ? -1 : torrent.activityDate,
                 dateAdded: torrent.addedDate,

--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -46,7 +46,10 @@ import {TorrentTrackerType} from '../../../shared/types/TorrentTracker';
 
 class QBittorrentClientGatewayService extends ClientGatewayService {
   private clientRequestManager = new ClientRequestManager(this.user.client as QBittorrentConnectionSettings);
-  private cachedProperties: Record<string, Pick<TorrentProperties, 'dateCreated' | 'isPrivate' | 'trackerURIs'>> = {};
+  private cachedProperties: Record<
+    string,
+    Pick<TorrentProperties, 'comment' | 'dateCreated' | 'isPrivate' | 'trackerURIs'>
+  > = {};
 
   async addTorrentsByFile({
     files,
@@ -358,6 +361,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
 
             if (properties != null && trackers != null && Array.isArray(trackers)) {
               this.cachedProperties[hash] = {
+                comment: properties?.comment,
                 dateCreated: properties?.creation_date,
                 isPrivate: trackers[0]?.msg.includes('is private'),
                 trackerURIs: getDomainsFromURLs(
@@ -374,10 +378,16 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
           {},
           ...(await Promise.all(
             infos.map(async (info) => {
-              const {dateCreated = 0, isPrivate = false, trackerURIs = []} = this.cachedProperties[info.hash] || {};
+              const {
+                comment = '',
+                dateCreated = 0,
+                isPrivate = false,
+                trackerURIs = [],
+              } = this.cachedProperties[info.hash] || {};
 
               const torrentProperties: TorrentProperties = {
                 bytesDone: info.completed,
+                comment: comment,
                 dateActive: info.dlspeed > 0 || info.upspeed > 0 ? -1 : info.last_activity,
                 dateAdded: info.added_on,
                 dateCreated,

--- a/server/services/rTorrent/constants/methodCallConfigs/torrentList.ts
+++ b/server/services/rTorrent/constants/methodCallConfigs/torrentList.ts
@@ -18,6 +18,17 @@ const torrentListMethodCallConfigs = {
     methodCall: 'd.state=',
     transformValue: booleanTransformer,
   },
+  comment: {
+    methodCall: 'd.custom2=',
+    transformValue: (value: unknown): string => {
+      // ruTorrent sets VRS24mrkr as a comment prefix, so we use it as well for compatability
+      if (value === '' || typeof value !== 'string' || value.indexOf('VRS24mrker') !== 0) {
+        return '';
+      }
+
+      return decodeURIComponent(value.substring(10));
+    },
+  },
   isActive: {
     methodCall: 'd.is_active=',
     transformValue: booleanTransformer,

--- a/server/util/torrentFileUtil.ts
+++ b/server/util/torrentFileUtil.ts
@@ -22,6 +22,16 @@ const openAndDecodeTorrent = async (torrentPath: string): Promise<TorrentFile | 
   return torrentData;
 };
 
+export const getComment = async (torrent: Buffer): Promise<string | undefined> => {
+  const torrentData: TorrentFile | null = await bencode.decode(torrent);
+
+  if (torrentData == null) {
+    return;
+  }
+
+  return torrentData.comment?.toString();
+};
+
 export const getContentSize = async (info: TorrentFile['info']): Promise<number> => {
   if (info.length != null) {
     // Single file torrent

--- a/shared/types/Torrent.ts
+++ b/shared/types/Torrent.ts
@@ -18,6 +18,7 @@ export enum TorrentPriority {
 
 export interface TorrentProperties {
   bytesDone: number;
+  comment: string;
   // Last time the torrent is active, -1 means currently active, 0 means data unavailable
   dateActive: number;
   dateAdded: number;


### PR DESCRIPTION
Mostly simple as it's supported by the various clients, except in the case of rtorrent.

For rtorrent, tags are stored in custom1, consistent with other clients. For that reason, comment is being stored in custom2,
which is also consistent with other clients. In particular, rutorrent uses a prefix on the comment for some reason, which is duplicated in this change to preserve cross-compatibility.

Also turns http: and https: text in comments into links, also consistent with other clients (and a main utility of having comments in the first place).

Fixes #435 

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
