### PR TITLE
API: torrents: add retrieval of summary for individual torrents

### DIFF
--- a/server/routes/api/torrents.test.ts
+++ b/server/routes/api/torrents.test.ts
@@ -16,7 +16,7 @@ import paths from '../../../shared/config/paths';
 import type {AddTorrentByFileOptions, AddTorrentByURLOptions} from '../../../shared/schema/api/torrents';
 import type {MoveTorrentsOptions, SetTorrentsTrackersOptions} from '../../../shared/types/api/torrents';
 import type {TorrentContent} from '../../../shared/types/TorrentContent';
-import type {TorrentList} from '../../../shared/types/Torrent';
+import type {TorrentList, TorrentProperties} from '../../../shared/types/Torrent';
 import type {TorrentStatus} from '../../../shared/constants/torrentStatusMap';
 import type {TorrentTracker} from '../../../shared/types/TorrentTracker';
 
@@ -488,6 +488,27 @@ describe('PATCH /api/torrents/trackers', () => {
         expect(trackers.filter((tracker) => testTrackers.includes(tracker.url)).length).toBeGreaterThanOrEqual(
           testTrackers.length,
         );
+
+        done();
+      });
+  });
+});
+
+describe('GET /api/torrents/{hash}', () => {
+  it('Gets torrent information', (done) => {
+    request
+      .get(`/api/torrents/${torrentHashes[0]}`)
+      .send()
+      .set('Cookie', [authToken])
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end((err, res) => {
+        if (err) done(err);
+
+        const contents: TorrentProperties = res.body;
+
+        expect(contents.hash).toBe(torrentHashes[0]);
 
         done();
       });

--- a/server/routes/api/torrents.ts
+++ b/server/routes/api/torrents.ts
@@ -38,6 +38,7 @@ import {
 import {accessDeniedError, fileNotFoundError, isAllowedPath, sanitizePath} from '../../util/fileUtil';
 import {getTempPath} from '../../models/TemporaryStorage';
 import {getToken} from '../../util/authUtil';
+import {TorrentProperties} from '@shared/types/Torrent';
 
 const getDestination = async (
   services: Express.Request['services'],
@@ -608,13 +609,22 @@ router.get<{hashes: string}>(
  */
 
 /**
- * TODO: API not yet implemented
  * GET /api/torrents/{hash}
  * @summary Gets information of a torrent.
  * @tags Torrent
  * @security User
  * @param {string} hash.path - Hash of a torrent
+ * @return {TorrentProperties} 200 - success response - application/json
+ * @return {Error} 500 - failure response - application/json
  */
+router.get(
+  '/:hash',
+  async (req, res): Promise<Response> =>
+    req.services.clientGatewayService.fetchTorrent(req.params.hash).then(
+      (contents) => res.status(200).json(contents),
+      ({code, message}) => res.status(500).json({code, message}),
+    ),
+);
 
 /**
  * GET /api/torrents/{hash}/contents

--- a/server/services/clientGatewayService.ts
+++ b/server/services/clientGatewayService.ts
@@ -184,6 +184,14 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
   abstract fetchTorrentList(): Promise<TorrentListSummary>;
 
   /**
+   * Fetches a torrent
+   *
+   * @param {string} hash - Hash of torrent
+   * @return {Promise<TorrentProperties>} - Resolves with TorrentProperties or rejects with error.
+   */
+  abstract fetchTorrent(hash: TorrentProperties['hash']): Promise<TorrentProperties>;
+
+  /**
    * Fetches the transfer summary
    *
    * @return {Promise<TransferSummary>} - Resolves with TransferSummary or rejects with error.


### PR DESCRIPTION
## Description

This allows fetching of summaries per torrent via the `/api/torrents/{hash}` route, which returns an instance of `TorrentProperties`.

## Related Issue

n/a

## Screenshots

n/a

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
