### PR TITLE
fix: escape torrent uri

### DIFF
--- a/server/routes/api/torrents.test.ts
+++ b/server/routes/api/torrents.test.ts
@@ -43,9 +43,14 @@ mock
   .onGet('https://www.torrents/multi.torrent')
   .reply(200, fs.readFileSync(path.join(paths.appSrc, 'fixtures/multi.torrent')));
 
+mock
+  .onGet('https://www.torrents/single with space.torrent')
+  .reply(200, fs.readFileSync(path.join(paths.appSrc, 'fixtures/single.torrent')));
+
 const torrentURLs: [string, ...string[]] = [
   'https://www.torrents/single.torrent',
   'https://www.torrents/multi.torrent',
+  'https://www.torrents/single with space.torrent',
 ];
 
 const torrentCookies = {

--- a/server/util/fetchUtil.ts
+++ b/server/util/fetchUtil.ts
@@ -18,7 +18,7 @@ export const fetchUrls = async (
 
         const file = await axios({
           method: 'GET',
-          url,
+          url: encodeURI(url),
           responseType: 'arraybuffer',
           headers: cookies?.[domain]
             ? {


### PR DESCRIPTION
## Description

In `fetchUrls`, escape the torrent URL to avoid errors of `TypeError: Request path contains unescaped characters`, when the torrent url contains spaces.

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
