### PR TITLE
server: torrentService: normalize case of hash during torrent lookup

### DIFF
--- a/server/services/torrentService.ts
+++ b/server/services/torrentService.ts
@@ -78,7 +78,7 @@ class TorrentService extends BaseService<TorrentServiceEvents> {
   };
 
   getTorrent(hash: TorrentProperties['hash']) {
-    return this.torrentListSummary.torrents[hash];
+    return this.torrentListSummary.torrents[hash.toUpperCase()];
   }
 
   getTorrentList() {


### PR DESCRIPTION
Fixes #581.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
