### PR TITLE
Log into qBittorrent using HTTP-POST

### DIFF
--- a/server/services/qBittorrent/clientRequestManager.ts
+++ b/server/services/qBittorrent/clientRequestManager.ts
@@ -1,3 +1,5 @@
+import {URLSearchParams} from 'url';
+
 import axios from 'axios';
 import FormData from 'form-data';
 
@@ -59,12 +61,13 @@ class ClientRequestManager {
     const {url, username, password} = connectionSettings;
 
     return axios
-      .get(`${url}/api/v2/auth/login`, {
-        params: {
+      .post(
+        `${url}/api/v2/auth/login`,
+        new URLSearchParams({
           username,
           password,
-        },
-      })
+        }),
+      )
       .then((res) => {
         const cookies = res.headers['set-cookie'];
 


### PR DESCRIPTION
## Description

The API endpoint for login changed in qBittorrent (violating semver).

This patch has been tested with qBittorrent 4.4.0 - 4.4.5.

## Related Issue

#592 

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
