### PR TITLE
Allow torrent download directory to take more width

### DIFF
--- a/client/src/sass/components/_torrent.scss
+++ b/client/src/sass/components/_torrent.scss
@@ -437,6 +437,10 @@ $more-info--border: floating-action.$textbox-repeater--button--border;
           width: 70px;
         }
 
+        &--directory {
+          width: auto;
+        }
+
         &--tags {
           &:last-child {
             margin-left: auto;


### PR DESCRIPTION
## Description

When using the "expanded view" and enabling the download location it only takes allows 100px to view the directory.

This change allows the directory detail to take up however much it needs – though perhaps it makes sense to add a sensible maximum width here, thoughts?

## Related Issue

N/A

## Screenshots

**before**
<img width="1223" alt="Screenshot 2022-09-18 at 16 11 58" src="https://user-images.githubusercontent.com/868844/190911620-4af4e54e-bd26-4b1f-acd5-db998d9cca99.png">

**after**
<img width="1222" alt="Screenshot 2022-09-18 at 16 12 08" src="https://user-images.githubusercontent.com/868844/190911624-735b9f44-5b45-4fbd-9d07-b7f0609cf813.png">

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
