### PR TITLE
Added a way to sort torrent peers columns

### DIFF
--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
@@ -80,42 +80,28 @@ const TorrentPeers: FC = () => {
           }}
           >
             <th className="torrent-details__table__heading--primary"
-                onClick={(event) => {
-                  sortPeerByProperty(event, 'address');
-                }}>
+                onClick={(event) => sortPeerByProperty(event, 'address')}
+            >
               <Trans id="torrents.details.peers" />
               <Badge>{peers.length}</Badge>
             </th>
             <th className="torrent-details__table__heading--primary"
-                onClick={(event) => {
-                  sortPeerByProperty(event, 'downloadRate');
-                }}
-            >DL
-            </th>
+                onClick={(event) => sortPeerByProperty(event, 'downloadRate')}
+            >DL</th>
             <th className="torrent-details__table__heading--primary"
-                onClick={(event) => {
-                  sortPeerByProperty(event, 'uploadRate');
-                }}
+                onClick={(event) => sortPeerByProperty(event, 'uploadRate')}
             >UL</th>
             <th className="torrent-details__table__heading--primary"
-                onClick={(event) => {
-                  sortPeerByProperty(event, 'completedPercent');
-                }}
+                onClick={(event) => sortPeerByProperty(event, 'completedPercent')}
             >%</th>
             <th className="torrent-details__table__heading--primary"
-                onClick={(event) => {
-                  sortPeerByProperty(event, 'clientVersion');
-                }}
+                onClick={(event) => sortPeerByProperty(event, 'clientVersion')}
             >Client</th>
             <th className="torrent-details__table__heading--primary"
-                onClick={(event) => {
-                  sortPeerByProperty(event, 'isEncrypted');
-                }}
+                onClick={(event) => sortPeerByProperty(event, 'isEncrypted')}
             >Enc</th>
             <th className="torrent-details__table__heading--primary"
-                onClick={(event) => {
-                  sortPeerByProperty(event, 'isIncoming');
-                }}
+                onClick={(event) => sortPeerByProperty(event, 'isIncoming')}
             >In</th>
           </tr>
         </thead>

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
@@ -54,6 +54,7 @@ const TorrentPeers: FC = () => {
 
     // then show the sorting arrow on the selected column
     clickedColumn.classList.add('table__heading', 'table__heading--is-sorted', `table__heading--direction--${nextDirection}`);
+    clickedColumn.style.border = 'none'; // hide border from the 'table__heading' class
 
     fetchPeers();
   }

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
@@ -37,6 +37,10 @@ const TorrentPeers: FC = () => {
   };
 
   const sortPeerByProperty = (event, property: TorrentPeerListColumn) => {
+
+    // don't do sorting when clicking on children elements
+    if (event.target !== event.currentTarget) return;
+
     const {sortPeers: sortBy} = SettingStore.floodSettings;
     const nextDirection: 'desc' | 'asc' = sortBy.direction === 'asc' ? 'desc': 'asc';
     const newSortBy = {

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
@@ -54,7 +54,6 @@ const TorrentPeers: FC = () => {
 
     // then show the sorting arrow on the selected column
     clickedColumn.classList.add('table__heading', 'table__heading--is-sorted', `table__heading--direction--${nextDirection}`);
-    clickedColumn.style.border = 'none'; // hide border from the 'table__heading' class
 
     fetchPeers();
   }
@@ -80,28 +79,28 @@ const TorrentPeers: FC = () => {
               cursor: 'pointer',
           }}
           >
-            <th className="torrent-details__table__heading--primary"
+            <th className="torrent-details__table__heading--primary table__heading--no-border"
                 onClick={(event) => sortPeerByProperty(event, 'address')}
             >
               <Trans id="torrents.details.peers" />
               <Badge>{peers.length}</Badge>
             </th>
-            <th className="torrent-details__table__heading--primary"
+            <th className="torrent-details__table__heading--primary table__heading--no-border"
                 onClick={(event) => sortPeerByProperty(event, 'downloadRate')}
             >DL</th>
-            <th className="torrent-details__table__heading--primary"
+            <th className="torrent-details__table__heading--primary table__heading--no-border"
                 onClick={(event) => sortPeerByProperty(event, 'uploadRate')}
             >UL</th>
-            <th className="torrent-details__table__heading--primary"
+            <th className="torrent-details__table__heading--primary table__heading--no-border"
                 onClick={(event) => sortPeerByProperty(event, 'completedPercent')}
             >%</th>
-            <th className="torrent-details__table__heading--primary"
+            <th className="torrent-details__table__heading--primary table__heading--no-border"
                 onClick={(event) => sortPeerByProperty(event, 'clientVersion')}
             >Client</th>
-            <th className="torrent-details__table__heading--primary"
+            <th className="torrent-details__table__heading--primary table__heading--no-border"
                 onClick={(event) => sortPeerByProperty(event, 'isEncrypted')}
             >Enc</th>
-            <th className="torrent-details__table__heading--primary"
+            <th className="torrent-details__table__heading--primary table__heading--no-border"
                 onClick={(event) => sortPeerByProperty(event, 'isIncoming')}
             >In</th>
           </tr>

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
@@ -10,6 +10,7 @@ import SettingStore from "@client/stores/SettingStore";
 import SettingActions from "@client/actions/SettingActions";
 
 import type {TorrentPeer} from '@shared/types/TorrentPeer';
+import type {TorrentPeerListColumn} from "@shared/types/TorrentPeer";
 
 import Badge from '../../general/Badge';
 import Size from '../../general/Size';
@@ -35,7 +36,7 @@ const TorrentPeers: FC = () => {
     setPollingDelay(ConfigStore.pollInterval);
   };
 
-  const sortPeerByProperty = (event, property: string) => {
+  const sortPeerByProperty = (event, property: TorrentPeerListColumn) => {
     const {sortPeers: sortBy} = SettingStore.floodSettings;
     const nextDirection: 'desc' | 'asc' = sortBy.direction === 'asc' ? 'desc': 'asc';
     const newSortBy = {

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
@@ -35,7 +35,7 @@ const TorrentPeers: FC = () => {
     setPollingDelay(ConfigStore.pollInterval);
   };
 
-  const sortPeerByProperty = (property: string) => {
+  const sortPeerByProperty = (event, property: string) => {
     const {sortPeers: sortBy} = SettingStore.floodSettings;
     const nextDirection: 'desc' | 'asc' = sortBy.direction === 'asc' ? 'desc': 'asc';
     const newSortBy = {
@@ -43,6 +43,17 @@ const TorrentPeers: FC = () => {
       property
     };
     SettingActions.saveSetting('sortPeers', newSortBy);
+
+    const clickedColumn = event.target
+
+    // clean classes linked to the sorting on every 'th'
+    clickedColumn.parentElement.querySelectorAll('th').forEach(th => {
+        th.classList.remove('table__heading', 'table__heading--is-sorted', 'table__heading--direction--asc', 'table__heading--direction--desc');
+    });
+
+    // then show the sorting arrow on the selected column
+    clickedColumn.classList.add('table__heading', 'table__heading--is-sorted', `table__heading--direction--${nextDirection}`);
+
     fetchPeers();
   }
 
@@ -62,24 +73,49 @@ const TorrentPeers: FC = () => {
           },
         }}
       >
-        <thead className="torrent-details__table__heading">
-          <tr>
+        <thead className="table__row torrent-details__table__heading">
+          <tr css={{
+              cursor: 'pointer',
+          }}
+          >
             <th className="torrent-details__table__heading--primary"
-                onClick={() => {
-                  sortPeerByProperty('address');
+                onClick={(event) => {
+                  sortPeerByProperty(event, 'address');
                 }}>
               <Trans id="torrents.details.peers" />
               <Badge>{peers.length}</Badge>
             </th>
-            <th className="torrent-details__table__heading--secondary"
-                onClick={() => {
-                  sortPeerByProperty('downloadRate');
-                }}>DL</th>
-            <th className="torrent-details__table__heading--secondary">UL</th>
-            <th className="torrent-details__table__heading--secondary">%</th>
-            <th className="torrent-details__table__heading--secondary">Client</th>
-            <th className="torrent-details__table__heading--secondary">Enc</th>
-            <th className="torrent-details__table__heading--secondary">In</th>
+            <th className="torrent-details__table__heading--primary"
+                onClick={(event) => {
+                  sortPeerByProperty(event, 'downloadRate');
+                }}
+            >DL
+            </th>
+            <th className="torrent-details__table__heading--primary"
+                onClick={(event) => {
+                  sortPeerByProperty(event, 'uploadRate');
+                }}
+            >UL</th>
+            <th className="torrent-details__table__heading--primary"
+                onClick={(event) => {
+                  sortPeerByProperty(event, 'completedPercent');
+                }}
+            >%</th>
+            <th className="torrent-details__table__heading--primary"
+                onClick={(event) => {
+                  sortPeerByProperty(event, 'clientVersion');
+                }}
+            >Client</th>
+            <th className="torrent-details__table__heading--primary"
+                onClick={(event) => {
+                  sortPeerByProperty(event, 'isEncrypted');
+                }}
+            >Enc</th>
+            <th className="torrent-details__table__heading--primary"
+                onClick={(event) => {
+                  sortPeerByProperty(event, 'isIncoming');
+                }}
+            >In</th>
           </tr>
         </thead>
         <tbody>

--- a/client/src/javascript/util/sortPeers.ts
+++ b/client/src/javascript/util/sortPeers.ts
@@ -1,0 +1,28 @@
+import {sort} from 'fast-sort';
+
+import type {FloodSettings} from '@shared/types/FloodSettings';
+import type {TorrentPeer} from '@shared/types/TorrentPeer';
+
+type SortRule = {
+    [direction in FloodSettings['sortPeers']['direction']]:
+    | keyof TorrentPeer
+    | ((p: TorrentPeer) => unknown);
+};
+
+function sortPeers(
+    peers: TorrentPeer[],
+    sortBy: Readonly<FloodSettings['sortPeers']>,
+): TorrentPeer[] {
+    const {property} = sortBy;
+    const sortRules: Array<SortRule> = [];
+
+    switch (property) {
+        default:
+            sortRules.push({[sortBy.direction]: property} as SortRule);
+            break;
+    }
+
+    return sort(peers).by(sortRules);
+}
+
+export default sortPeers;

--- a/client/src/javascript/util/sortPeers.ts
+++ b/client/src/javascript/util/sortPeers.ts
@@ -17,6 +17,22 @@ function sortPeers(
     const sortRules: Array<SortRule> = [];
 
     switch (property) {
+
+        // we sort numerically by the first IP block
+        case 'address':
+            const sortedData = peers.sort((p1: TorrentPeer, p2: TorrentPeer) => {
+                return p1.address.split('.')[0] - p2.address.split('.')[0];
+            })
+            return sortBy.direction === 'asc' ? sortedData : sortedData.reverse();
+
+        // we sort clients as case-insensitive
+        case 'clientVersion':
+            sortRules.push({
+                [sortBy.direction]: (p: TorrentPeer) => p.clientVersion.toLowerCase(),
+            } as SortRule);
+            break;
+
+        // default alphabetically
         default:
             sortRules.push({[sortBy.direction]: property} as SortRule);
             break;

--- a/client/src/javascript/util/sortPeers.ts
+++ b/client/src/javascript/util/sortPeers.ts
@@ -18,11 +18,25 @@ function sortPeers(
 
     switch (property) {
 
-        // we sort numerically by the first IP block
+        // we sort numerically for IPv4 and alphabetically for IPv6 using the first IP block
         case 'address':
-            const sortedData = peers.sort((p1: TorrentPeer, p2: TorrentPeer) => {
+
+            // prepare arrays
+            const ipv4 = peers.filter((value) => value.address.includes('.'));
+            const ipv6 = peers.filter((value) => value.address.includes(':'));
+
+            // sort v4
+            const sortedIpv4 = ipv4.sort((p1: TorrentPeer, p2: TorrentPeer) => {
                 return p1.address.split('.')[0] - p2.address.split('.')[0];
             })
+
+            // sort v6
+            const sortedIpv6 = ipv6.sort((p1: TorrentPeer, p2: TorrentPeer) => {
+                return (p1.address.split(':')[0] < p2.address.split(':')[0]) ? -1 : 1;
+            })
+
+            // then return sorted data
+            const sortedData = sortedIpv4.concat(sortedIpv6);
             return sortBy.direction === 'asc' ? sortedData : sortedData.reverse();
 
         // we sort clients as case-insensitive

--- a/client/src/sass/components/_table.scss
+++ b/client/src/sass/components/_table.scss
@@ -31,7 +31,7 @@ $table--heading--resize--indicator--width: 1px;
     transition: color 0.15s;
     touch-action: none;
 
-    &:last-child {
+    &:last-child, &--no-border {
       border-right: none;
     }
 

--- a/shared/constants/defaultFloodSettings.ts
+++ b/shared/constants/defaultFloodSettings.ts
@@ -7,8 +7,8 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
     property: 'dateAdded',
   },
   sortPeers: {
-    direction: 'desc',
-    property: 'downloadRate',
+    direction: 'asc',
+    property: 'address',
   },
   torrentListColumns: [
     {id: 'name', visible: true},

--- a/shared/constants/defaultFloodSettings.ts
+++ b/shared/constants/defaultFloodSettings.ts
@@ -6,6 +6,10 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
     direction: 'desc',
     property: 'dateAdded',
   },
+  sortPeers: {
+    direction: 'desc',
+    property: 'downloadRate',
+  },
   torrentListColumns: [
     {id: 'name', visible: true},
     {id: 'percentComplete', visible: true},

--- a/shared/types/FloodSettings.ts
+++ b/shared/types/FloodSettings.ts
@@ -8,6 +8,10 @@ export interface FloodSettings {
     direction: 'desc' | 'asc';
     property: TorrentListColumn;
   };
+  sortPeers: {
+    direction: 'desc' | 'asc';
+    property: string;
+  };
   torrentListColumns: Array<{
     id: TorrentListColumn;
     visible: boolean;

--- a/shared/types/FloodSettings.ts
+++ b/shared/types/FloodSettings.ts
@@ -1,6 +1,7 @@
 import type {Language} from '../../client/src/javascript/constants/Languages';
 import type {TorrentContextMenuAction} from '../../client/src/javascript/constants/TorrentContextMenuActions';
 import type {TorrentListColumn} from '../../client/src/javascript/constants/TorrentListColumns';
+import type {TorrentPeerListColumn} from "@shared/types/TorrentPeer";
 
 export interface FloodSettings {
   language: Language;
@@ -10,7 +11,7 @@ export interface FloodSettings {
   };
   sortPeers: {
     direction: 'desc' | 'asc';
-    property: string;
+    property: TorrentPeerListColumn;
   };
   torrentListColumns: Array<{
     id: TorrentListColumn;

--- a/shared/types/TorrentPeer.ts
+++ b/shared/types/TorrentPeer.ts
@@ -8,3 +8,4 @@ export interface TorrentPeer {
   isEncrypted: boolean;
   isIncoming: boolean;
 }
+export type TorrentPeerListColumn = keyof TorrentPeer;


### PR DESCRIPTION
## Description

I've found sad that we didn't have the ability to sort the "Torrent Peers" table.

More precisely, currently it seems to be sorted automatically on the the backend side by IPs.

Personally, I'm always curious to see which peers are giving me the best download speeds and to where I'm uploading the faster.

## Screenshots

<img width="829" alt="screenshot" src="https://user-images.githubusercontent.com/23384755/200671411-8f5989fe-5044-4a14-9fcf-d2108cbeac21.png">

## Types of changes

 So I've implemented a logic to sort columns on a click and I've followed the project logic to don't diverge too much from the main idea.

It is possible to sort by any columns and in any direction.

Note that the sort can handle IPv4/v6 too.

---

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [X] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
