### PR TITLE
exec mediainfo without splitting arg

### DIFF
--- a/server/routes/api/torrents.ts
+++ b/server/routes/api/torrents.ts
@@ -905,7 +905,7 @@ router.get<{hash: string}>(
 
       const mediainfoProcess = childProcess.execFile(
         'mediainfo',
-        torrentContentPaths,
+        `"${torrentContentPaths}"`,
         {maxBuffer: 1024 * 2000, timeout: 1000 * 10},
         (error, stdout) => {
           if (error) {


### PR DESCRIPTION
Have often run info that error, where mediainfo couldnt execute corrently, because my file had spaces in it. This fixed it
(Running on a Raspberry Pi of release executable)
