### PR TITLE
Add tag (label) support for Deluge and adjust UI to accommodate

### DIFF
--- a/client/src/javascript/components/general/form-elements/TagSelect.tsx
+++ b/client/src/javascript/components/general/form-elements/TagSelect.tsx
@@ -100,7 +100,7 @@ const TagSelect: FC<TagSelectProps> = ({defaultValue, placeholder, id, label, on
             <ContextMenu
               isIn={isOpen}
               onClick={(event) => {
-                if (SettingStore.floodSettings.UITagSelectorMode !== 'single') {
+                if (SettingStore.floodSettings.UITagSelectorMode === 'multi') {
                   event.nativeEvent.stopImmediatePropagation();
                 }
               }}
@@ -125,12 +125,22 @@ const TagSelect: FC<TagSelectProps> = ({defaultValue, placeholder, id, label, on
                     key={tag}
                     isSelected={selectedTags.includes(tag)}
                     onClick={() => {
-                      if (tag === 'untagged') {
-                        setSelectedTags([]);
-                      } else if (selectedTags.includes(tag)) {
-                        setSelectedTags(selectedTags.filter((key) => key !== tag && key !== ''));
-                      } else {
-                        setSelectedTags([...selectedTags.filter((key) => key !== ''), tag]);
+                      if (SettingStore.floodSettings.UITagSelectorMode === 'singleStrict') {
+                        if (tag === 'untagged' || selectedTags.includes(tag)) {
+                          setSelectedTags([]);
+                        } 
+                        else {
+                          setSelectedTags([tag]);
+                        }
+                      }
+                      else {
+                        if (tag === 'untagged') {
+                          setSelectedTags([]);
+                        } else if (selectedTags.includes(tag)) {
+                          setSelectedTags(selectedTags.filter((key) => key !== tag && key !== ''));
+                        } else {
+                          setSelectedTags([...selectedTags.filter((key) => key !== ''), tag]);
+                        }
                       }
                     }}
                   >

--- a/client/src/javascript/components/modals/settings-modal/UITab.tsx
+++ b/client/src/javascript/components/modals/settings-modal/UITab.tsx
@@ -23,7 +23,7 @@ const UITab: FC<UITabProps> = ({onSettingsChange}: UITabProps) => {
   const [torrentListViewSize, setTorrentListViewSize] = useState(SettingStore.floodSettings.torrentListViewSize);
   const [selectedLanguage, setSelectedLanguage] = useState(SettingStore.floodSettings.language);
   const [UITagSelectorMode, setUITagSelectorMode] = useState(SettingStore.floodSettings.UITagSelectorMode);
-
+  const tagModeChangeDisabled = SettingStore.clientSettings?.tagSupport !== 'multi';
   return (
     <Form
       onChange={({event, formData}) => {
@@ -63,11 +63,32 @@ const UITab: FC<UITabProps> = ({onSettingsChange}: UITabProps) => {
         <Trans id="settings.ui.tag.selector.mode" />
       </ModalFormSectionHeader>
       <FormRow>
-        <Radio defaultChecked={UITagSelectorMode === 'single'} groupID="ui-tag-selector-mode" id="single" width="auto">
+        <Radio 
+          disabled={tagModeChangeDisabled} 
+          defaultChecked={UITagSelectorMode === 'single'} 
+          groupID="ui-tag-selector-mode" 
+          id="single" 
+          width="auto"
+        >
           <Trans id="settings.ui.tag.selector.mode.single" />
         </Radio>
-        <Radio defaultChecked={UITagSelectorMode === 'multi'} groupID="ui-tag-selector-mode" id="multi" width="auto">
+        <Radio 
+          disabled={tagModeChangeDisabled}
+          defaultChecked={UITagSelectorMode === 'multi'}
+          groupID="ui-tag-selector-mode"
+          id="multi"
+          width="auto"
+        >
           <Trans id="settings.ui.tag.selector.mode.multi" />
+        </Radio>
+        <Radio
+          defaultChecked={UITagSelectorMode === 'singleStrict'}
+          groupID="ui-tag-selector-mode"
+          id="singleStrict"
+          width="auto"
+        >
+          {/* <Trans id="settings.ui.tag.selector.mode.multi" /> */}
+          single strict
         </Radio>
       </FormRow>
       <ModalFormSectionHeader>

--- a/client/src/javascript/components/modals/settings-modal/UITab.tsx
+++ b/client/src/javascript/components/modals/settings-modal/UITab.tsx
@@ -63,6 +63,14 @@ const UITab: FC<UITabProps> = ({onSettingsChange}: UITabProps) => {
         <Trans id="settings.ui.tag.selector.mode" />
       </ModalFormSectionHeader>
       <FormRow>
+        <Radio
+          defaultChecked={UITagSelectorMode === 'singleStrict'}
+          groupID="ui-tag-selector-mode"
+          id="singleStrict"
+          width="auto"
+        >
+          <Trans id="settings.ui.tag.selector.mode.singleStrict" />
+        </Radio>
         <Radio 
           disabled={tagModeChangeDisabled} 
           defaultChecked={UITagSelectorMode === 'single'} 
@@ -80,15 +88,6 @@ const UITab: FC<UITabProps> = ({onSettingsChange}: UITabProps) => {
           width="auto"
         >
           <Trans id="settings.ui.tag.selector.mode.multi" />
-        </Radio>
-        <Radio
-          defaultChecked={UITagSelectorMode === 'singleStrict'}
-          groupID="ui-tag-selector-mode"
-          id="singleStrict"
-          width="auto"
-        >
-          {/* <Trans id="settings.ui.tag.selector.mode.multi" /> */}
-          single strict
         </Radio>
       </FormRow>
       <ModalFormSectionHeader>

--- a/client/src/javascript/i18n/strings/en.json
+++ b/client/src/javascript/i18n/strings/en.json
@@ -216,6 +216,7 @@
   "settings.ui.tag.selector.mode": "Tag Selector Preference",
   "settings.ui.tag.selector.mode.multi": "Multi Selection",
   "settings.ui.tag.selector.mode.single": "Single Selection",
+  "settings.ui.tag.selector.mode.singleStrict": "Strict Single Selection",
   "settings.ui.torrent.context.menu.items.show": "Show",
   "settings.ui.torrent.details.enabled": "Enabled",
   "settings.ui.torrent.details.tags.placement": "In the expanded view, tags work best at the end of the list.",

--- a/client/src/javascript/stores/SettingStore.ts
+++ b/client/src/javascript/stores/SettingStore.ts
@@ -34,6 +34,10 @@ class SettingStore {
 
   handleClientSettingsFetchSuccess(settings: ClientSettings) {
     this.fetchStatus.clientSettingsFetched = true;
+    console.log(settings.tagSupport)
+    if (settings.tagSupport === 'single') {
+      this.floodSettings.UITagSelectorMode = 'singleStrict';
+    }
     this.clientSettings = settings;
   }
 

--- a/client/src/javascript/stores/SettingStore.ts
+++ b/client/src/javascript/stores/SettingStore.ts
@@ -34,7 +34,6 @@ class SettingStore {
 
   handleClientSettingsFetchSuccess(settings: ClientSettings) {
     this.fetchStatus.clientSettingsFetched = true;
-    console.log(settings.tagSupport)
     if (settings.tagSupport === 'single') {
       this.floodSettings.UITagSelectorMode = 'singleStrict';
     }
@@ -43,6 +42,9 @@ class SettingStore {
 
   handleSettingsFetchSuccess(settings: Partial<FloodSettings>): void {
     this.fetchStatus.floodSettingsFetched = true;
+    if (this.clientSettings?.tagSupport === 'single') {
+      settings.UITagSelectorMode = 'singleStrict';
+    }
     Object.assign(this.floodSettings, settings);
   }
 

--- a/client/src/javascript/ui/components/ToggleInput.tsx
+++ b/client/src/javascript/ui/components/ToggleInput.tsx
@@ -14,6 +14,7 @@ export interface ToggleInputProps {
   value?: InputHTMLAttributes<HTMLInputElement>['value'];
   defaultChecked?: InputHTMLAttributes<HTMLInputElement>['defaultChecked'];
   checked?: InputHTMLAttributes<HTMLInputElement>['checked'];
+  disabled?: InputHTMLAttributes<HTMLInputElement>['disabled'];
   shrink?: FormRowItemProps['shrink'];
   grow?: FormRowItemProps['grow'];
   width?: FormRowItemProps['width'];
@@ -31,6 +32,7 @@ const ToggleInput: FC<ToggleInputProps> = ({
   value,
   defaultChecked,
   checked,
+  disabled,
   shrink,
   grow,
   width,
@@ -53,6 +55,7 @@ const ToggleInput: FC<ToggleInputProps> = ({
         <input
           defaultChecked={defaultChecked}
           checked={checked}
+          disabled={disabled}
           className="toggle-input__element"
           name={type === 'radio' ? groupID : id}
           onClick={(event) => {

--- a/client/src/sass/ui/components/input.scss
+++ b/client/src/sass/ui/components/input.scss
@@ -178,6 +178,22 @@
         }
       }
     }
+
+    &:disabled {
+      & ~ .toggle-input__label {
+        color: colors.$grey--soft
+      }
+      & ~ .toggle-input__indicator {
+        background-color: colors.$grey--soft;
+        box-shadow: none;
+        border-color: colors.$darkest-grey--hard;
+        .inverse & {
+          background-color: colors.$grey--soft;
+          box-shadow: none;
+          border-color: colors.$darkest-grey--hard;
+        }
+      }
+    }
   }
 
   &__indicator {

--- a/server/services/Deluge/clientGatewayService.ts
+++ b/server/services/Deluge/clientGatewayService.ts
@@ -235,11 +235,9 @@ class DelugeClientGatewayService extends ClientGatewayService {
   }
 
   async setTorrentsTags({hashes, tags}: SetTorrentsTagsOptions): Promise<void> {
-    console.log(hashes, tags)
     const available = await this.availableTags;
     if (available === undefined) {
       // Label plugin disabled, do nothing
-      console.log("skip")
       return
     }
     const tag = tags[0] ?? '';

--- a/server/services/Deluge/clientRequestManager.ts
+++ b/server/services/Deluge/clientRequestManager.ts
@@ -276,6 +276,18 @@ class ClientRequestManager {
     await this.methodCall(['daemon.login', [username, actualPassword], {client_version}], false);
   }
 
+  async labelAdd(label: string): Promise<void> {
+    await this.methodCall(['label.add', [label], {}]);
+  }
+
+  async labelAddTorrent(torrent_id: string, label: string): Promise<void> {
+    await this.methodCall(['label.set_torrent', [torrent_id.toLowerCase(), label], {}]);
+  }
+
+  async labelGetLabels(): Promise<string[]> {
+    return this.methodCall(['label.get_labels', [], {}]) as Promise<string[]>;
+  }
+
   async reconnect(): Promise<void> {
     await (this.rpcWithAuth = (this.rpc = this.connect()).then((rpc) => this.daemonLogin().then(() => rpc)));
   }

--- a/server/services/Deluge/types/DelugeCoreMethods.ts
+++ b/server/services/Deluge/types/DelugeCoreMethods.ts
@@ -114,6 +114,7 @@ export interface DelugeCoreTorrentStatuses {
   auto_managed: unknown;
   is_auto_managed: unknown;
   is_finished: unknown;
+  label: string | undefined;
   max_connections: unknown;
   max_download_speed: unknown;
   max_upload_slots: unknown;
@@ -143,7 +144,7 @@ export interface DelugeCoreTorrentStatuses {
   total_payload_upload: number;
   total_peers: number;
   total_seeds: number;
-  total_uploaded: unknown;
+  total_uploaded: number;
   total_wanted: unknown;
   total_remaining: unknown;
   tracker: unknown;

--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -491,6 +491,7 @@ class TransmissionClientGatewayService extends ClientGatewayService {
           piecesHashOnCompletion: false,
           piecesMemoryMax: 0,
           protocolPex: properties['pex-enabled'],
+          tagSupport: 'multi',
           throttleGlobalDownSpeed: properties['speed-limit-down-enabled'] ? properties['speed-limit-down'] * 1024 : 0,
           throttleGlobalUpSpeed: properties['speed-limit-up-enabled'] ? properties['speed-limit-up'] * 1024 : 0,
           throttleMaxPeersNormal: 0,

--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -490,6 +490,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
           piecesHashOnCompletion: false,
           piecesMemoryMax: 0,
           protocolPex: preferences.pex,
+          tagSupport: 'multi',
           throttleGlobalDownSpeed: preferences.dl_limit,
           throttleGlobalUpSpeed: preferences.up_limit,
           throttleMaxPeersNormal: 0,

--- a/server/services/rTorrent/clientGatewayService.ts
+++ b/server/services/rTorrent/clientGatewayService.ts
@@ -737,8 +737,9 @@ class RTorrentClientGatewayService extends ClientGatewayService {
       .methodCall('system.multicall', [methodCalls])
       .then(this.processClientRequestSuccess, this.processRTorrentRequestError)
       .then((response) => {
-        return processMethodCallResponse(response, clientSettingMethodCallConfigs);
-      });
+        return processMethodCallResponse(response, clientSettingMethodCallConfigs)
+      })
+      .then((settings) => {return {tagSupport: 'multi', ...settings}});
   }
 
   async setClientSettings(settings: SetClientSettingsOptions): Promise<void> {
@@ -753,6 +754,9 @@ class RTorrentClientGatewayService extends ClientGatewayService {
       }
 
       switch (property) {
+        // can't change tagSupport since it's a readonly setting
+        case 'tagSupport':
+          return accumulator;
         case 'dht':
           methodName = 'dht.mode.set';
           param = (param as ClientSettings[typeof property]) ? 'auto' : 'disable';

--- a/shared/constants/defaultFloodSettings.ts
+++ b/shared/constants/defaultFloodSettings.ts
@@ -77,6 +77,7 @@ const defaultFloodSettings: Readonly<FloodSettings> = {
   deleteTorrentData: true,
   startTorrentsOnLoad: true,
   UIPageTitleSpeedEnabled: true,
+  UITagSelectorMode: 'multi',
 };
 
 export default defaultFloodSettings;

--- a/shared/types/ClientSettings.ts
+++ b/shared/types/ClientSettings.ts
@@ -11,6 +11,7 @@ export interface ClientSettings {
   piecesHashOnCompletion: boolean;
   piecesMemoryMax: number;
   protocolPex: boolean;
+  tagSupport: false | "single" | "multi"
   // B/s
   throttleGlobalDownSpeed: number;
   // B/s

--- a/shared/types/FloodSettings.ts
+++ b/shared/types/FloodSettings.ts
@@ -36,7 +36,7 @@ export interface FloodSettings {
   torrentDestinations?: Record<string, string>;
 
   // Tag selector preference
-  UITagSelectorMode?: 'single' | 'multi';
+  UITagSelectorMode?: 'single' | 'multi' | 'singleStrict';
 
   // Last used "Add Torrents" tab
   UITorrentsAddTab?: 'by-url' | 'by-file' | 'by-creation';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add tag support for Deluge (using the built in Labels plugin). Deluge only supports a single Label per torrent, so I introduce a new Tag selection UI preference "Single Strict" which allows you to select at most one tag when assigning tags.

To enforce this behavior for Deluge, the frontend checks the new readonly `clientSettings.tagSupport` and disables changing the tag UI mode if label support is limited to one-label-per-torrent.

Also fixes Deluge torrents showing 0B uploaded/0B downloaded.

TODO

- ~~skip RPCs if Labels plugin is inactive/unavailable~~ done

## Related Issue

#607 

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
