### PR TITLE
Add scripts for rss auto download

### DIFF
--- a/client/src/javascript/components/modals/feeds-modal/DownloadRuleForm.tsx
+++ b/client/src/javascript/components/modals/feeds-modal/DownloadRuleForm.tsx
@@ -102,6 +102,9 @@ const DownloadRuleForm: FC<DownloadRuleFormProps> = ({
         </Textbox>
       </FormRow>
       <FormRow>
+        <Textbox id="script" label={i18n._('feeds.script')} defaultValue={rule.script} />
+      </FormRow>
+      <FormRow>
         <FormRowItem>
           <FilesystemBrowserTextbox
             id="destination"

--- a/client/src/javascript/components/modals/feeds-modal/DownloadRulesTab.tsx
+++ b/client/src/javascript/components/modals/feeds-modal/DownloadRulesTab.tsx
@@ -17,6 +17,7 @@ const initialRule: AddRuleOptions = {
   feedIDs: [],
   match: '',
   exclude: '',
+  script: '',
   tags: [],
   destination: '',
   startOnLoad: false,
@@ -36,7 +37,12 @@ const validatedFields = {
     error: 'feeds.validation.must.specify.label',
   },
   match: {
-    isValid: (value: string | undefined) => isNotEmpty(value) && isRegExValid(value),
+    isValid: (value: string | undefined) => {
+      if (isNotEmpty(value)) {
+        return isRegExValid(value);
+      }
+      return true;
+    },
     error: 'feeds.validation.invalid.regular.expression',
   },
   exclude: {
@@ -64,6 +70,7 @@ interface RuleFormData {
   feedID: string;
   label: string;
   match: string;
+  script: string;
   tags: string;
   isBasePath: boolean;
   startOnLoad: boolean;
@@ -140,6 +147,7 @@ const DownloadRulesTab: FC = () => {
             field: formData.field,
             match: formData.match ?? initialRule.match,
             exclude: formData.exclude ?? initialRule.exclude,
+            script: formData.script ?? initialRule.script,
             destination: formData.destination ?? initialRule.destination,
             tags: formData.tags?.split(',') ?? initialRule.tags,
             startOnLoad: formData.startOnLoad ?? initialRule.startOnLoad,

--- a/client/src/javascript/i18n/strings/en.json
+++ b/client/src/javascript/i18n/strings/en.json
@@ -102,6 +102,7 @@
   "feeds.no.items.matching": "No items matching search term.",
   "feeds.no.rules.defined": "No rules defined.",
   "feeds.regEx": "RegEx",
+  "feeds.script": "Script",
   "feeds.search": "Search term",
   "feeds.search.term": "Search term",
   "feeds.select.feed": "Select Feed",

--- a/server/routes/api/feed-monitor.test.ts
+++ b/server/routes/api/feed-monitor.test.ts
@@ -220,6 +220,7 @@ describe('PUT /api/feed-monitor/rules', () => {
     feedIDs: [''],
     match: '',
     exclude: '.*',
+    script: '',
     destination: tempDirectory,
     tags: ['FeedItem'],
     startOnLoad: false,

--- a/shared/types/Feed.ts
+++ b/shared/types/Feed.ts
@@ -27,6 +27,8 @@ export interface Rule {
   match: string;
   // Regular expression to exclude items.
   exclude: string;
+  // Custom script to select if the item should be downloaded (exit with status 80 to download).
+  script: string;
   // Destination path where matched items are downloaded to.
   destination: string;
   // Tags to be added when items are queued for download.


### PR DESCRIPTION
## Description

Allow users to define a script to decide if a rss item should be downloaded or not. If the scripts return the magic code of 80 (and regex match if it is specified), the item will be downloaded.

This PR also specifies a user agent of 'flood' for http requests used to retrieve the rss since some servers sent 403 when no user agent was specified.

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
