### PR TITLE
Detect magnet and torrent links from clipboard on paste

### DIFF
--- a/client/src/javascript/components/torrent-list/TorrentList.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentList.tsx
@@ -14,6 +14,7 @@ import SettingStore from '@client/stores/SettingStore';
 import TorrentFilterStore from '@client/stores/TorrentFilterStore';
 import TorrentStore from '@client/stores/TorrentStore';
 import SortDirections from '@client/constants/SortDirections';
+import UIStore from '@client/stores/UIStore';
 
 import type {TorrentListColumn} from '@client/constants/TorrentListColumns';
 
@@ -50,7 +51,7 @@ const TorrentList: FC = observer(() => {
   useEvent('keydown', (e: KeyboardEvent) => {
     const {ctrlKey, key, metaKey, repeat, target} = e;
 
-    const tagName = (target as HTMLElement)?.tagName.toUpperCase();
+    const tagName = (target as HTMLElement)?.tagName?.toUpperCase();
     if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
       return;
     }
@@ -62,6 +63,18 @@ const TorrentList: FC = observer(() => {
     if ((metaKey || ctrlKey) && key === 'a') {
       e.preventDefault();
       TorrentStore.selectAllTorrents();
+    }
+
+    if ((metaKey || ctrlKey) && key === 'v') {
+      (async () => {
+        const text = await navigator?.clipboard?.readText();
+        const isMagnetLink = text?.startsWith('magnet:?');
+        const isTorrentLink = text?.startsWith('http') && text?.endsWith('.torrent');
+        if (isMagnetLink || isTorrentLink) {
+          e.preventDefault();
+          UIStore.setActiveModal({id: 'add-torrents', tab: 'by-url', urls: [{id: 0, value: text}]});
+        }
+      })();
     }
   });
 


### PR DESCRIPTION
# Detect magnet and torrent links from clipboard on paste

## Description

- Feat: detects magnet links on paste, opens new torrent modal with link pre-filled

## Related Issue

- #689 : Split this PR in-two

## Screenshots

Detect magnet link in clipboard (CTRL+V) - if detected, open new torrent modal with link pre-filled:
![chrome_tUIicDyWUT](https://github.com/jesec/flood/assets/17837575/e317b1db-83df-4741-872e-b90ba07012f8)

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
