### PR TITLE
fix(client): react render logic

### DIFF
--- a/client/src/javascript/components/sidebar/NotificationsButton.tsx
+++ b/client/src/javascript/components/sidebar/NotificationsButton.tsx
@@ -63,15 +63,14 @@ const NotificationTopToolbar: FC<NotificationTopToolbarProps> = ({
 };
 
 interface NotificationItemProps {
-  index: number;
   notification: Notification;
 }
 
-const NotificationItem: FC<NotificationItemProps> = ({index, notification}: NotificationItemProps) => {
+const NotificationItem: FC<NotificationItemProps> = ({notification}: NotificationItemProps) => {
   const {i18n} = useLingui();
 
   return (
-    <li className="notifications__list__item" key={index}>
+    <li className="notifications__list__item">
       <div className="notification__heading">
         <span className="notification__category">{i18n._(`${notification.id}.heading`)}</span>
         {' — '}
@@ -195,7 +194,7 @@ const NotificationsButton: FC = observer(() => {
               style={{minHeight: prevHeight}}
             >
               {notifications.map((notification, index) => (
-                <NotificationItem index={index} notification={notification} />
+                <NotificationItem key={index} notification={notification} />
               ))}
             </ul>
             <NotificationBottomToolbar

--- a/client/src/javascript/components/sidebar/SidebarFilter.tsx
+++ b/client/src/javascript/components/sidebar/SidebarFilter.tsx
@@ -63,7 +63,7 @@ const SidebarFilter: FC<SidebarFilterProps> = ({
         {icon}
         <span className="name">{name}</span>
         <Badge>{count}</Badge>
-        {size && <Size value={size} className="size" />}
+        {size != null && <Size value={size} className="size" />}
       </button>
     </li>
   );


### PR DESCRIPTION
# fix(client): react render logic

A couple react related fixes. One fixes a console error, the other an unwanted rendered result.

## Description

- Fix: `key={}` must be set on the rendered component (cannot be passed down and set within the component)
- Fix: conditional rendering via `&&` must be a conditional statement (not relying on value truthy/falsy) otherwise a `0` value will be rendered
  - Using `!=` to fix instead of `!==` because it catches both `null` and `undefined` values

## Related Issue

N/A

## Screenshots

![Screenshot 2023-12-09 234933](https://github.com/jesec/flood/assets/17837575/ac224a94-fc6d-4a27-82bb-3f1e8778a004)

Before / After
![Screenshot 2023-12-09 235115](https://github.com/jesec/flood/assets/17837575/bd54fe04-c7d1-4f4f-83e8-c446b98a4689)
![Screenshot 2023-12-09 235057](https://github.com/jesec/flood/assets/17837575/c1534d84-8ed1-4176-81a5-30b94999101e)

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
