### PR TITLE
fix(server): `@fastify/express` doesn't work with http2

### DIFF
--- a/server/bin/web-server.ts
+++ b/server/bin/web-server.ts
@@ -24,7 +24,6 @@ const startWebServer = async () => {
     instance = fastify({
       bodyLimit: 100 * 1024 * 1024,
       trustProxy: 'loopback',
-      http2: false,
       https: {
         allowHTTP1: true,
         key: fs.readFileSync(config.sslKey),

--- a/server/bin/web-server.ts
+++ b/server/bin/web-server.ts
@@ -25,7 +25,6 @@ const startWebServer = async () => {
       bodyLimit: 100 * 1024 * 1024,
       trustProxy: 'loopback',
       https: {
-        allowHTTP1: true,
         key: fs.readFileSync(config.sslKey),
         cert: fs.readFileSync(config.sslCert),
       },

--- a/server/bin/web-server.ts
+++ b/server/bin/web-server.ts
@@ -24,7 +24,7 @@ const startWebServer = async () => {
     instance = fastify({
       bodyLimit: 100 * 1024 * 1024,
       trustProxy: 'loopback',
-      http2: true,
+      http2: false,
       https: {
         allowHTTP1: true,
         key: fs.readFileSync(config.sslKey),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

close https://github.com/jesec/flood/issues/696

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [X] Bug fix (non-breaking change which fixes an issue - semver PATCH)
