### PR TITLE
Fix mobile modal overflow

### DIFF
--- a/client/src/sass/components/_modals.scss
+++ b/client/src/sass/components/_modals.scss
@@ -155,7 +155,6 @@ $modal--tabs--padding--vertical--left: $modal--padding--horizontal;
       height: auto;
       left: 50%;
       max-height: 80%;
-      width: 500px;
       max-width: 80%;
       overflow: hidden;
       position: absolute;
@@ -163,6 +162,7 @@ $modal--tabs--padding--vertical--left: $modal--padding--horizontal;
       transition: transform $modal--transition--duration;
       transform: translate(-50%, 0);
       transform-origin: 50% 50%;
+      min-width: 500px;
 
       @media (max-width: 720px) {
         max-width: 100%;

--- a/client/src/sass/components/_modals.scss
+++ b/client/src/sass/components/_modals.scss
@@ -156,7 +156,6 @@ $modal--tabs--padding--vertical--left: $modal--padding--horizontal;
       left: 50%;
       max-height: 80%;
       width: 500px;
-      min-width: max-content;
       max-width: 80%;
       overflow: hidden;
       position: absolute;

--- a/client/src/sass/components/_modals.scss
+++ b/client/src/sass/components/_modals.scss
@@ -155,6 +155,8 @@ $modal--tabs--padding--vertical--left: $modal--padding--horizontal;
       height: auto;
       left: 50%;
       max-height: 80%;
+      width: 500px;
+      min-width: max-content;
       max-width: 80%;
       overflow: hidden;
       position: absolute;
@@ -162,7 +164,6 @@ $modal--tabs--padding--vertical--left: $modal--padding--horizontal;
       transition: transform $modal--transition--duration;
       transform: translate(-50%, 0);
       transform-origin: 50% 50%;
-      min-width: 500px;
 
       @media (max-width: 720px) {
         max-width: 100%;
@@ -170,6 +171,7 @@ $modal--tabs--padding--vertical--left: $modal--padding--horizontal;
         width: 100%;
         top: unset;
         bottom: 0%;
+        min-width: unset;
       }
     }
 


### PR DESCRIPTION
The modal was overflowing on mobile viewports following changes in https://github.com/jesec/flood/pull/597

## Description

This PR unsets the `min-width` for mobile viewports.

## Related Issue

Fixes https://github.com/jesec/flood/issues/711

## Screenshots

<img width="462" alt="Screenshot 2023-12-19 at 22 45 31" src="https://github.com/jesec/flood/assets/868844/a22f6eef-d450-4b31-8208-55b7cac4ad6e">

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
