### PR TITLE
Add config file flag

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -194,6 +194,8 @@ const {argv: argvObj} = yargs(process.argv.slice(2))
     hidden: true,
     type: 'boolean',
   })
+  .config()
+  .alias('c', 'config')
   .version(version)
   .alias('v', 'version')
   .help();


### PR DESCRIPTION
Adds a config file flag to load in config parameters from a JSON file.

## Description

Lets users load in command line configuration files as a JSON file using the `-c` or `--config` flags. Options compose, so options set by the command line and the config will combine. If the same option is set by both, the command line value takes precedence. Provided file _must_ be valid JSON and have the `.json` file extension. Tested by running with the `--config` flag set to a file containing:

```json
{
  "port": 3001
}
```

My use-case is that I'm using nix to configure Flood and providing the secret values for authentication as command line arguments would leak them to the nix store which means non-root users would be able to see the secrets.

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
