### PR TITLE
Update ko i18n string

### DIFF
--- a/client/src/javascript/i18n/strings/ko.json
+++ b/client/src/javascript/i18n/strings/ko.json
@@ -383,7 +383,7 @@
   "unit.size.kilobyte": "kB",
   "unit.size.megabyte": "MB",
   "unit.size.terabyte": "TB",
-  "unit.speed": "초당 {baseUnit}",
+  "unit.speed": "{baseUnit}/s",
   "unit.time.day": "일",
   "unit.time.hour": "시간",
   "unit.time.infinity": "∞",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In Korean, the phrase "초당 {baseUnit}" is very unnatural. In general, the "{baseUnit}/s" unit is usually used in Korean as well, and it is more natural.
<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
