### PR TITLE
fix(qBittorrent): Add torrent files without authentication

### DIFF
--- a/server/services/qBittorrent/clientRequestManager.ts
+++ b/server/services/qBittorrent/clientRequestManager.ts
@@ -422,7 +422,7 @@ class ClientRequestManager {
     });
 
     const headers = form.getHeaders({
-      Cookie: await this.authCookie,
+      ...(await this.getRequestHeaders()),
       'Content-Length': form.getLengthSync(),
     });
 


### PR DESCRIPTION
Fixes add torrent files with no authentication using qbittorrent.

## Description

authCookie resolves to undefined when used without authentication. This lead to axios throwing ERR_HTTP_INVALID_HEADER_VALUE. Fixed to use the same method getRequestHeaders instead of the direct this.authCookie call, so it does not try to send the request with Cookie: undefined header.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
