### PR TITLE
Add a user agent for rss

### DIFF
--- a/server/models/FeedReader.ts
+++ b/server/models/FeedReader.ts
@@ -54,6 +54,11 @@ class FeedReader {
       maxHistory: this.options.maxHistory,
       interval: this.options.interval,
       forceInterval: true,
+      requestOpts: {
+        headers: {
+          'User-Agent': 'flood',
+        },
+      },
     });
 
     this.reader.on('items', this.handleFeedItems);


### PR DESCRIPTION
## Description

Adds a user agent to the http call used to retrive rss feeds. This is needed because some rss servers refuses to answer if no user agent is set.

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
