### PR TITLE
changed transmission ratio calculation to total size instead of downloaded size

### DIFF
--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -383,7 +383,10 @@ class TransmissionClientGatewayService extends ClientGatewayService {
           ...(await Promise.all(
             torrents.map(async (torrent) => {
               const percentComplete = (torrent.haveValid / torrent.totalSize) * 100;
-              const ratio = torrent.totalSize === 0 ? -1 : torrent.uploadedEver / torrent.totalSize;
+              const ratio =
+                torrent.downloadedEver === 0
+                  ? torrent.uploadedEver / torrent.totalSize
+                  : torrent.uploadedEver / torrent.downloadedEver;
               const trackerURIs = getDomainsFromURLs(torrent.trackers.map((tracker) => tracker.announce));
               const status = torrentPropertiesUtil.getTorrentStatus(torrent);
 

--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -383,7 +383,7 @@ class TransmissionClientGatewayService extends ClientGatewayService {
           ...(await Promise.all(
             torrents.map(async (torrent) => {
               const percentComplete = (torrent.haveValid / torrent.totalSize) * 100;
-              const ratio = torrent.downloadedEver === 0 ? -1 : torrent.uploadedEver / torrent.downloadedEver;
+              const ratio = torrent.totalSize === 0 ? -1 : torrent.uploadedEver / torrent.totalSize;
               const trackerURIs = getDomainsFromURLs(torrent.trackers.map((tracker) => tracker.announce));
               const status = torrentPropertiesUtil.getTorrentStatus(torrent);
 


### PR DESCRIPTION
Transmission ratio calculation was based on ```torrent.uploadedEver/torrent.downloadedEver```, which caused some torrents not initiated in flood to have a ratio of -1.

## Description

The calculation is now based on ```torrent.uploadedEver / torrent.totalSize```

## Related Issue
#720

## Screenshots

Before change:

Note the ratio is -1

![image](https://github.com/user-attachments/assets/c6c2c034-d689-4d1f-8d50-a0e1b25e7777)

After change

Note the ratio is now correctly displayed: 0.01

![image](https://github.com/user-attachments/assets/b9f888ad-acda-4ac2-b3dd-e0f6fca5a6c4)

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
