### PR TITLE
fix: #800 resume and pause does not work with qbittorrent 5

### DIFF
--- a/server/services/qBittorrent/util/apiVersionCheck.ts
+++ b/server/services/qBittorrent/util/apiVersionCheck.ts
@@ -1,0 +1,16 @@
+export function isApiVersionAtLeast(currentVersion: string | null, targetVersion: string): boolean {
+  if (!currentVersion) {
+    return false;
+  }
+  const v1 = currentVersion.split('.').map(Number);
+  const v2 = targetVersion.split('.').map(Number);
+
+  for (let i = 0; i < Math.max(v1.length, v2.length); i++) {
+    const num1 = v1[i] || 0;
+    const num2 = v2[i] || 0;
+
+    if (num1 > num2) return true;
+    if (num1 < num2) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In qBittorrent 5.0.0 (webapi v2.11.0 and above) the method name for **pause** and **resume** torrent has been changed to **stop** and **start**. This fix check whether the webapi is 2.11 or above and if so it uses the correct method names.

<!--- Describe your changes in detail -->


## Related Issue

https://github.com/jesec/flood/issues/800

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
