### PR TITLE
fix: add_paused changed to add_stopped in qbit 5

### DIFF
--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -38,6 +38,7 @@ import {getDomainsFromURLs} from '../../util/torrentPropertiesUtil';
 import ClientGatewayService from '../clientGatewayService';
 import ClientRequestManager from './clientRequestManager';
 import {QBittorrentTorrentContentPriority, QBittorrentTorrentTrackerStatus} from './types/QBittorrentTorrentsMethods';
+import {isApiVersionAtLeast} from './util/apiVersionCheck';
 import {
   getTorrentPeerPropertiesFromFlags,
   getTorrentStatusFromState,
@@ -88,7 +89,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
       .torrentsAddFiles(fileBuffers, {
         savepath: destination,
         tags: tags.join(','),
-        paused: !start,
+        [isApiVersionAtLeast(this.clientRequestManager.apiVersion, '2.11.0') ? 'stopped' : 'paused']: !start,
         root_folder: !isBasePath,
         contentLayout: isBasePath ? 'NoSubfolder' : undefined,
         sequentialDownload: isSequential,
@@ -122,7 +123,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
       .torrentsAddURLs(urls, {
         savepath: destination,
         tags: tags.join(','),
-        paused: !start,
+        [isApiVersionAtLeast(this.clientRequestManager.apiVersion, '2.11.0') ? 'stopped' : 'paused']: !start,
         root_folder: !isBasePath,
         contentLayout: isBasePath ? 'NoSubfolder' : undefined,
         sequentialDownload: isSequential,

--- a/server/services/qBittorrent/clientRequestManager.ts
+++ b/server/services/qBittorrent/clientRequestManager.ts
@@ -36,7 +36,7 @@ const EMPTY_SERVER_STATE = {
 class ClientRequestManager {
   private connectionSettings: QBittorrentConnectionSettings;
   private apiBase: string;
-  private apiVersion: string | null = null;
+  apiVersion: string | null = null;
   private authCookie: Promise<string | undefined> = Promise.resolve(undefined);
   private isMainDataPending = false;
 

--- a/server/services/qBittorrent/types/QBittorrentTorrentsMethods.ts
+++ b/server/services/qBittorrent/types/QBittorrentTorrentsMethods.ts
@@ -123,6 +123,8 @@ export interface QBittorrentTorrentsAddOptions {
   skip_checking?: boolean;
   // Add torrents in the paused state. Possible values are true, false (default)
   paused?: boolean;
+  // Add torrents in the stopped state (using webapiVersion v2.11.0 or later). Possible values are true, false (default)
+  stopped?: boolean;
   // Create the root folder. Possible values are true, false, unset (default)
   root_folder?: boolean;
   // Content layout mode, replaces root_folder


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In Qbittorrent 5 and later the "add_paused" option is changed to "add_stopped". This fix checks the apiversion and uses the correct key.
<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes
Dynamically set add_paused or add_stopped depending on apiversion
<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
