### PR TITLE
fix(qBittorrent): API Version state handling

### DIFF
--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -85,11 +85,12 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
       throw new Error();
     }
 
+    const method = isApiVersionAtLeast(await this.clientRequestManager.apiVersion, '2.11.0') ? 'stopped' : 'paused';
     await this.clientRequestManager
       .torrentsAddFiles(fileBuffers, {
         savepath: destination,
         tags: tags.join(','),
-        [isApiVersionAtLeast(this.clientRequestManager.apiVersion, '2.11.0') ? 'stopped' : 'paused']: !start,
+        [method]: !start,
         root_folder: !isBasePath,
         contentLayout: isBasePath ? 'NoSubfolder' : undefined,
         sequentialDownload: isSequential,
@@ -119,11 +120,12 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
       throw new Error();
     }
 
+    const method = isApiVersionAtLeast(await this.clientRequestManager.apiVersion, '2.11.0') ? 'stopped' : 'paused';
     await this.clientRequestManager
       .torrentsAddURLs(urls, {
         savepath: destination,
         tags: tags.join(','),
-        [isApiVersionAtLeast(this.clientRequestManager.apiVersion, '2.11.0') ? 'stopped' : 'paused']: !start,
+        [method]: !start,
         root_folder: !isBasePath,
         contentLayout: isBasePath ? 'NoSubfolder' : undefined,
         sequentialDownload: isSequential,
@@ -526,7 +528,7 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
 
   async testGateway(): Promise<void> {
     return this.clientRequestManager
-      .updateAuthCookie()
+      .updateConnection()
       .then(() => this.processClientRequestSuccess(undefined), this.processClientRequestError);
   }
 }

--- a/server/services/qBittorrent/util/apiVersionCheck.ts
+++ b/server/services/qBittorrent/util/apiVersionCheck.ts
@@ -1,4 +1,4 @@
-export function isApiVersionAtLeast(currentVersion: string | null, targetVersion: string): boolean {
+export function isApiVersionAtLeast(currentVersion: string | undefined, targetVersion: string): boolean {
   if (!currentVersion) {
     return false;
   }


### PR DESCRIPTION
## Description
When Flood is started **before** a qBittorrent 5 client, starting and stopping torrents will fail due to the wrong method being called.

This is happening due to Flood getting the API Version in the clientRequestManager constructor ([clientRequestManager.ts#L626](https://github.com/jesec/flood/blob/843b9c966cabcbcc542210ee0d08c4262255278f/server/services/qBittorrent/clientRequestManager.ts#L626)) and nowhere else. If this request fails then the `apiVersion` will remain null until Flood is restarted.

I made the `apiVersion` consistent with the `authCookie` so that it's kept in sync with the qBittorrent client and can be awaited to ensure the value is resolved. I also renamed `updateAuthCookie` to `updateConnection` so that it better represents what the method is now doing.

As `getApiVersion` requires authentication I've chained the promises so that it runs only when `authenticate` is successful.

The changes to `clientGatewayService` are to make the calls to `isApiVersionAtLeast` consistent with `clientRequestManager`.

## Related Issue
#820 

## Screenshots

## Types of changes
- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [X] Bug fix (non-breaking change which fixes an issue - semver PATCH)