### PR TITLE
fix(rTorrent): prevent extra commas in serialized XML

### DIFF
--- a/server/services/rTorrent/util/XMLRPCSerializer.ts
+++ b/server/services/rTorrent/util/XMLRPCSerializer.ts
@@ -46,7 +46,7 @@ const value = (value: XMLRPCValue): string => {
 };
 
 const data = (values: XMLRPCValue[]) => {
-  return `<data>${values.map(value)}</data>`;
+  return `<data>${values.map(value).join('')}</data>`;
 };
 
 const member = ([key, val]: [string, XMLRPCValue]) => {
@@ -64,7 +64,7 @@ const param = (param: XMLRPCValue) => {
 const sParams = (params: XMLRPCValue[]) => {
   if (!params?.length) return '';
 
-  return `<params>${params.map(param)}</params>`;
+  return `<params>${params.map(param).join('')}</params>`;
 };
 
 const serializeSync = (methodName: string, params: XMLRPCValue[]): string => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I just happened to notice this while taking tcpdumps between flood and rTorrent, it doesn't appear to have an negative impact (both xmlrpc-c and tinyxml2 just ignore it), but I tracked it down out of curiosity.

Commands for testing:
```js
console.log(value(["foo", "bar"]));
console.log(sParams(["foo", "bar"]));
```
Before:
```
<value><array><data><value><string>foo</string></value>,<value><string>bar</string></value></data></array></value>
<params><param><value><string>foo</string></value></param>,<param><value><string>bar</string></value></param></params>
```
After:
```
<value><array><data><value><string>foo</string></value><value><string>bar</string></value></data></array></value>
<params><param><value><string>foo</string></value></param><param><value><string>bar</string></value></param></params>
```

## Related Issue

N/A

## Screenshots

N/A

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
