### PR TITLE
Run compaction every `dbclean` interval

### DIFF
--- a/server/models/Users.ts
+++ b/server/models/Users.ts
@@ -31,6 +31,7 @@ class Users {
     });
 
     db.ensureIndex({fieldName: 'username', unique: true});
+    db.setAutocompactionInterval(config.dbCleanInterval);
 
     return db;
   })();

--- a/server/services/feedService.ts
+++ b/server/services/feedService.ts
@@ -21,6 +21,7 @@ class FeedService extends BaseService<Record<string, never>> {
 
   constructor(...args: ConstructorParameters<typeof BaseService>) {
     super(...args);
+    this.db.setAutocompactionInterval(config.dbCleanInterval);
 
     this.onServicesUpdated = async () => {
       // Execute once only.

--- a/server/services/notificationService.ts
+++ b/server/services/notificationService.ts
@@ -26,6 +26,7 @@ class NotificationService extends BaseService<NotificationServiceEvents> {
 
   constructor(...args: ConstructorParameters<typeof BaseService>) {
     super(...args);
+    this.db.setAutocompactionInterval(config.dbCleanInterval);
 
     (async () => {
       const notifications = await this.db.findAsync<Notification>({}).catch(() => undefined);

--- a/server/services/settingService.ts
+++ b/server/services/settingService.ts
@@ -21,6 +21,11 @@ class SettingService extends BaseService<SettingServiceEvents> {
     filename: path.join(config.dbPath, this.user._id, 'settings', 'settings.db'),
   });
 
+  constructor(...args: ConstructorParameters<typeof BaseService>) {
+    super(...args);
+    this.db.setAutocompactionInterval(config.dbCleanInterval);
+  }
+
   async destroy(drop: boolean) {
     if (drop) {
       await this.db.dropDatabaseAsync();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description

Run `nedb` compaction every `dbclean` interval. `nedb` only appends a deleted tag for data deletion, so deleting data won't shrink the on-disk datastore size. Compaction rewrites the entire DB into datastore.

This was originally intended to fix #399, #645, but that was apparently already fixed in af8de75e0593a48864d64c84c2e1c12d9ff0a7e1. However, it's still in theory for other datastores to write too much stuff into datastores (e.g. feed), so compaction after db cleanup should help.

## Related Issue

#399, #645.
https://github.com/jesec/flood/issues/399#issuecomment-2241635132 also mentioned the transmission log, which doesn't seem to be managed by `nedb`. That is out-of-scope of this PR.

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
