### PR TITLE
Check if user services is bootstrapped before removing instances

### DIFF
--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -46,6 +46,8 @@ export const destroyUserServices = async (userId: UserInDatabase['_id'], drop = 
 
   delete serviceInstances[userId];
 
+  if (userServiceInstances === undefined || userServiceInstances === null) return;
+
   return Promise.all(
     Object.keys(userServiceInstances).map((key) => userServiceInstances[key as keyof ServiceInstances].destroy(drop)),
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During user deletion, check if `userServiceInstance` is not `null` or `undefined` before deleting them. This can happen in cases such as migration (so the users are not yet loaded).

This was a cause of an old migration bug (#401, `userV1` -> `userV2`). I doubt if anyone is still using the v1 user format, but let's not be sorry.

## Related Issue

Closes #401

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
