### PR TITLE
Added units of measure to throttle speeds

### DIFF
--- a/client/src/javascript/components/modals/settings-modal/BandwidthTab.tsx
+++ b/client/src/javascript/components/modals/settings-modal/BandwidthTab.tsx
@@ -90,12 +90,20 @@ const BandwidthTab: FC<BandwidthTabProps> = ({onSettingsChange, onClientSettings
       <FormRow>
         <Textbox
           defaultValue={getChangedClientSetting(changedClientSettings, 'throttleGlobalDownSpeed')}
-          label={<Trans id="settings.bandwidth.transferrate.global.throttle.download" />}
+          label={
+            <div>
+              <Trans id="settings.bandwidth.transferrate.global.throttle.download" /> <em className="unit">(B/s)</em>
+            </div>
+          }
           id="throttleGlobalDownSpeed"
         />
         <Textbox
           defaultValue={getChangedClientSetting(changedClientSettings, 'throttleGlobalUpSpeed')}
-          label={<Trans id="settings.bandwidth.transferrate.global.throttle.upload" />}
+          label={
+            <div>
+              <Trans id="settings.bandwidth.transferrate.global.throttle.upload" /> <em className="unit">(B/s)</em>
+            </div>
+          }
           id="throttleGlobalUpSpeed"
         />
       </FormRow>


### PR DESCRIPTION
## Description

I had this issue in the past which led me to find (and answer) the linked discussion page.

But I had the issue again today, so decided to implement a fix.

I considered adding translations for:

```
settings.bandwidth.transferrate.global.throttle.download
settings.bandwidth.transferrate.global.throttle.upload
```

For every language as some have their own preferred units of measure, but B/s seems fairly universal.

There was precedent for this change in [`client/src/javascript/components/modals/settings-modal/ResourcesTab.tsx`](https://github.com/jesec/flood/blob/master/client/src/javascript/components/modals/settings-modal/ResourcesTab.tsx)

## Related Issue

#546

## Screenshots

### Before:

<img width="832" alt="Screenshot 2025-07-07 at 2 43 02 PM" src="https://github.com/user-attachments/assets/f9dfb6dc-a57f-4edb-8119-95f28d75f8f0" />

### After:

<img width="843" alt="image" src="https://github.com/user-attachments/assets/af8ec797-6235-4506-a946-76f3e018c0d6" />

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [X] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
