### PR TITLE
fix: improve server startup message

### DIFF
--- a/server/bin/web-server.ts
+++ b/server/bin/web-server.ts
@@ -43,9 +43,16 @@ const startWebServer = async () => {
   } else {
     await instance.listen({port: Number(port), host});
   }
-  const address = chalk.underline(`${ssl ? 'https' : 'http'}://${host}:${port}`);
 
-  console.log(chalk.green(`Flood server ${packageJSON.version} starting on ${address}\n`));
+  for (const addressObject of instance.addresses()) {
+    let hostname = addressObject.address;
+    if (addressObject.family == 'IPv6') {
+      hostname = `[${addressObject.address}]`;
+    }
+    const address = chalk.underline(`${ssl ? 'https' : 'http'}://${hostname}:${addressObject.port}`);
+
+    console.log(chalk.green(`Flood server ${packageJSON.version} starting on ${address}\n`));
+  }
 
   if (config.authMethod === 'none') {
     console.log(chalk.yellow('Starting without builtin authentication\n'));


### PR DESCRIPTION
## Description
This makes use of server's addresses and distinguishes between IPv4 and IPv6 family in order to print correct URI, as defined in RFC2732.

Links referencing IPv6 address space will be correctly formatted and clickable. As shown on screenshots below, binding to `::` resulted in `http://:::3000` which no browser (or any agent) would accept.

## Related Issue
None.

## Screenshots

### Before
<img width="817" height="69" alt="image" src="https://github.com/user-attachments/assets/3654e55f-7c78-49da-a2ff-1c9a1386e7ea" />
<img width="703" height="89" alt="image" src="https://github.com/user-attachments/assets/b5f091d8-69ca-4ec9-b0db-1562d18b3325" />


### After
<img width="817" height="135" alt="image" src="https://github.com/user-attachments/assets/676a4ec5-bae6-4a1a-8c8d-f66e12e3e2c3" />
<img width="735" height="81" alt="image" src="https://github.com/user-attachments/assets/d2ae1614-480d-4ed7-ada1-2c376b2f4b0a" />

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
