### PR TITLE
fix(rtorrent): ignore seq download input then rtorrent doesn't support it

### DIFF
--- a/server/services/rTorrent/util/torrentPropertiesUtil.ts
+++ b/server/services/rTorrent/util/torrentPropertiesUtil.ts
@@ -93,6 +93,8 @@ export const encodeTags = (tags: TorrentProperties['tags']): string => {
     .join(',');
 };
 
+export const SEQUENTIAL_SET_METHOD = 'd.down.sequential.set';
+
 export const getAddTorrentPropertiesCalls = ({
   destination,
   isBasePath,
@@ -113,7 +115,7 @@ export const getAddTorrentPropertiesCalls = ({
   }
 
   if (isSequential) {
-    result.push(`d.down.sequential.set=1`);
+    result.push(`${SEQUENTIAL_SET_METHOD}=1`);
   }
 
   if (isInitialSeeding) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
