### PR TITLE
fix: remove meta tags conflicting with manifest.json

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -6,10 +6,6 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="apple-mobile-web-app-title" content="Flood" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <link rel="manifest" href="manifest.json" />
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="icon_maskable_180x180.png" />


### PR DESCRIPTION
## Description

In index.html files there is a couple tags that conflict manifest.json (theme-color and apple-mobile-web-app-*):
https://github.com/jesec/flood/blob/01f5a4aa55f97b8edbf67269c982f80537872908/client/src/index.html#L9-12

https://github.com/jesec/flood/blob/master/client/src/public/manifest.json

From what I read in the following documentation, those tags should be remove altogether:
https://web.dev/learn/pwa/web-app-manifest#designing_your_pwa_experience


## Related Issue

 #943 

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
