### PR TITLE
feat: support searching torrents by info hash

### DIFF
--- a/client/src/javascript/stores/TorrentStore.ts
+++ b/client/src/javascript/stores/TorrentStore.ts
@@ -40,6 +40,7 @@ class TorrentStore {
       const nameMatchedHashes = new Set(
         termMatch(filteredTorrents, (properties) => properties.name, searchFilter).map((p) => p.hash),
       );
+      // Fuzzy match torrent names, exact match infohash (after trim/lowercase).
       const normalizedSearchFilter = searchFilter.trim().toLowerCase();
 
       filteredTorrents = filteredTorrents.filter(


### PR DESCRIPTION
this PR adds info hashes to the search term for each torrent that the search query matches against. The matching is already case-insensitive so it supports both uppercase info hashes and lowercase info hashes. 