### PR TITLE
fix(ui): restore desktop sidebar toggle behavior

### DIFF
--- a/client/src/javascript/components/layout/ApplicationView.tsx
+++ b/client/src/javascript/components/layout/ApplicationView.tsx
@@ -4,16 +4,21 @@ import {observer} from 'mobx-react-lite';
 
 import UIStore from '@client/stores/UIStore';
 
+export enum ApplicationViewModifier {
+  AuthForm = 'auth-form',
+}
+
 interface ApplicationViewProps {
   children: ReactNode;
-  modifier?: string;
+  modifier?: ApplicationViewModifier;
 }
 
 const ApplicationView: FC<ApplicationViewProps> = observer(({children, modifier}: ApplicationViewProps) => {
-  const classes = classnames('application__view', {
-    [`application__view--${modifier}`]: modifier != null,
-    'application__view--sidebar-alternative-state': UIStore.isSidebarAlternativeState,
-  });
+  const classes = classnames(
+    'application__view',
+    modifier != null && `application__view--${modifier}`,
+    UIStore.isSidebarAlternativeState && 'application__view--sidebar-alternative-state',
+  );
 
   return <div className={classes}>{children}</div>;
 });

--- a/client/src/javascript/components/layout/ApplicationView.tsx
+++ b/client/src/javascript/components/layout/ApplicationView.tsx
@@ -1,17 +1,21 @@
 import classnames from 'classnames';
 import {FC, ReactNode} from 'react';
+import {observer} from 'mobx-react-lite';
+
+import UIStore from '@client/stores/UIStore';
 
 interface ApplicationViewProps {
   children: ReactNode;
   modifier?: string;
 }
 
-const ApplicationView: FC<ApplicationViewProps> = ({children, modifier}: ApplicationViewProps) => {
+const ApplicationView: FC<ApplicationViewProps> = observer(({children, modifier}: ApplicationViewProps) => {
   const classes = classnames('application__view', {
     [`application__view--${modifier}`]: modifier != null,
+    'application__view--sidebar-alternative-state': UIStore.isSidebarAlternativeState,
   });
 
   return <div className={classes}>{children}</div>;
-};
+});
 
 export default ApplicationView;

--- a/client/src/javascript/components/layout/ApplicationView.tsx
+++ b/client/src/javascript/components/layout/ApplicationView.tsx
@@ -6,6 +6,7 @@ import UIStore from '@client/stores/UIStore';
 
 export enum ApplicationViewModifier {
   AuthForm = 'auth-form',
+  SidebarAlternativeState = 'sidebar-alternative-state',
 }
 
 interface ApplicationViewProps {
@@ -14,10 +15,19 @@ interface ApplicationViewProps {
 }
 
 const ApplicationView: FC<ApplicationViewProps> = observer(({children, modifier}: ApplicationViewProps) => {
+  const activeModifiers: Array<ApplicationViewModifier> = [];
+
+  if (modifier != null) {
+    activeModifiers.push(modifier);
+  }
+
+  if (UIStore.isSidebarAlternativeState) {
+    activeModifiers.push(ApplicationViewModifier.SidebarAlternativeState);
+  }
+
   const classes = classnames(
     'application__view',
-    modifier != null && `application__view--${modifier}`,
-    UIStore.isSidebarAlternativeState && 'application__view--sidebar-alternative-state',
+    ...activeModifiers.map((activeModifier) => `application__view--${activeModifier}`),
   );
 
   return <div className={classes}>{children}</div>;

--- a/client/src/javascript/components/torrent-list/ActionBar.tsx
+++ b/client/src/javascript/components/torrent-list/ActionBar.tsx
@@ -28,12 +28,7 @@ const ActionBar: FC = observer(() => {
           label="actionbar.button.sidebar.expand.collapse"
           slug="sidebar-expand-collapse"
           icon={<Menu />}
-          clickHandler={() => {
-            const view = document.getElementsByClassName('application__view')[0];
-            if (view != null) {
-              view.classList.toggle('application__view--sidebar-alternative-state');
-            }
-          }}
+          clickHandler={() => UIStore.toggleSidebarAlternativeState()}
           noTip
         />
       </div>

--- a/client/src/javascript/routes/Login.tsx
+++ b/client/src/javascript/routes/Login.tsx
@@ -1,10 +1,10 @@
 import {FC} from 'react';
 
-import ApplicationView from '@client/components/layout/ApplicationView';
+import ApplicationView, {ApplicationViewModifier} from '@client/components/layout/ApplicationView';
 import AuthForm from '@client/components/auth/AuthForm';
 
 const LoginView: FC = () => (
-  <ApplicationView modifier="auth-form">
+  <ApplicationView modifier={ApplicationViewModifier.AuthForm}>
     <AuthForm mode="login" />
   </ApplicationView>
 );

--- a/client/src/javascript/routes/Register.tsx
+++ b/client/src/javascript/routes/Register.tsx
@@ -1,10 +1,10 @@
 import {FC} from 'react';
 
 import AuthForm from '@client/components/auth/AuthForm';
-import ApplicationView from '@client/components/layout/ApplicationView';
+import ApplicationView, {ApplicationViewModifier} from '@client/components/layout/ApplicationView';
 
 const LoginView: FC = () => (
-  <ApplicationView modifier="auth-form">
+  <ApplicationView modifier={ApplicationViewModifier.AuthForm}>
     <AuthForm mode="register" />
   </ApplicationView>
 );

--- a/client/src/javascript/stores/UIStore.ts
+++ b/client/src/javascript/stores/UIStore.ts
@@ -92,6 +92,7 @@ class UIStore {
   activeContextMenu: ActiveContextMenu | null = null;
   activeDropdownMenu: string | null = null;
   activeModal: Modal | null = null;
+  isSidebarAlternativeState = false;
   dependencies: Dependencies = {};
   globalStyles: Array<string> = [];
   haveUIDependenciesResolved = false;
@@ -183,6 +184,10 @@ class UIStore {
 
   setActiveModal(modal: this['activeModal']) {
     this.activeModal = modal;
+  }
+
+  toggleSidebarAlternativeState() {
+    this.isSidebarAlternativeState = !this.isSidebarAlternativeState;
   }
 
   verifyDependencies() {

--- a/client/src/sass/base/_layout.scss
+++ b/client/src/sass/base/_layout.scss
@@ -31,12 +31,25 @@ body {
 
     &--sidebar-alternative-state {
       .application__sidebar {
-        display: none;
+        flex: 0 0 0;
+        min-width: 0;
+        max-width: 0;
+        width: 0;
+        overflow: hidden;
+        opacity: 0;
+        pointer-events: none;
       }
 
       @media (max-width: 720px) {
         .application__sidebar {
           display: flex;
+          flex: 1;
+          min-width: 240px;
+          max-width: 250px;
+          width: auto;
+          overflow: visible;
+          opacity: 1;
+          pointer-events: auto;
           transform: translateX(120px);
           z-index: unset;
         }


### PR DESCRIPTION
## Summary
- fix sidebar toggle on desktop where the hamburger button no longer collapsed/restored the sidebar
- replace imperative DOM class mutation with UIStore state + declarative class rendering
- make sidebar alternative state collapse resilient to OverlayScrollbars host styles on desktop
- preserve existing mobile sidebar behavior

## Root cause
The desktop collapse depended on display:none for .application__sidebar, which can be neutralized by OverlayScrollbars host display rules after the frontend style layering changes in the v4.12.0 stack.

## Validation
- pnpm run check-types
- pnpm run lint

Fixes #1036