### PR TITLE
Correct Polish language name from 'Polskie' to 'Polski'

### DIFF
--- a/client/src/javascript/constants/Languages.ts
+++ b/client/src/javascript/constants/Languages.ts
@@ -11,7 +11,7 @@ const Languages = {
   hu: 'Magyar',
   nl: 'Nederlands',
   no: 'norsk',
-  pl: 'Polskie',
+  pl: 'Polski',
   pt: 'português',
   ru: 'русский язык',
   ro: 'Romanian',


### PR DESCRIPTION
## Description

Corrected the Polish language name from 'Polskie' to the proper form 'Polski' to ensure grammatical correctness and consistency with standard language naming conventions.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
