### PR TITLE
fix: encode file path for @fastify/send to handle special characters

### DIFF
--- a/server/routes/api/torrents.ts
+++ b/server/routes/api/torrents.ts
@@ -828,7 +828,8 @@ const torrentsRoutes = async (fastify: FastifyInstance) => {
         const fileName = path.basename(file);
         const fileExt = path.extname(file);
 
-        const result = await send(request.raw, file, {
+        // @fastify/send expects a urlencoded path, not the actual filesystem path.
+        const result = await send(request.raw, encodeURI(file), {
           acceptRanges: true,
           lastModified: true,
         });


### PR DESCRIPTION
## Problem

The \/api/torrents/:hash/contents/:indices/data\ endpoint returns HTTP 400 for some torrent files.

\@fastify/send\ calls \ast-decode-uri-component()\ on the path parameter before using it. When a torrent file's actual path on disk contains a literal \%\ character (e.g. \[100%].mkv\), the URI decoder encounters an invalid percent-encoding sequence, returns \
ull\, and \@fastify/send\ responds with status 400.

## Fix

Use \ncodeURI()\ on the file path before passing it to \send()\. The library's decoder then correctly reverses the encoding back to the real filesystem path. The \@fastify/send\ type definition explicitly documents that the path parameter should be *urlencoded, not the actual file-system path*.