### PR TITLE
fix: use relative asset paths so --baseuri works with Vite build

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo userdocs/qbittorrent-nox-static --tag release-5.1.4_v2.0.12 --pattern 'x86_64-qbittorrent-nox' --dir /tmp
+          gh release download --repo userdocs/qbittorrent-nox-static release-5.1.4_v2.0.12 --pattern 'x86_64-qbittorrent-nox' --dir /tmp
           mv /tmp/x86_64-qbittorrent-nox /usr/local/bin/qbittorrent-nox
           chmod +x /usr/local/bin/qbittorrent-nox
 

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo userdocs/qbittorrent-nox-static --pattern 'x86_64-qbittorrent-nox' --dir /tmp
+          gh release download --repo userdocs/qbittorrent-nox-static --tag release-5.1.4_v2.0.12 --pattern 'x86_64-qbittorrent-nox' --dir /tmp
           mv /tmp/x86_64-qbittorrent-nox /usr/local/bin/qbittorrent-nox
           chmod +x /usr/local/bin/qbittorrent-nox
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import {defineConfig} from 'vite';
 
 export default defineConfig({
   root: 'client/src',
+  base: './',
   publicDir: 'public',
   resolve: {
     alias: {


### PR DESCRIPTION
Vite defaults `base` to `/`, which makes the built HTML reference assets with absolute paths like `/assets/index-xxx.js`. When `--baseuri` is set (e.g. `/flood`), the server registers routes under that prefix, but the browser still requests assets from the root — resulting in 404s.

Setting `base: './'` in the Vite config makes all asset references relative, so `./assets/xxx` correctly resolves under any base URI.

Fixes #1109