### PR TITLE
docs: update stale references to webpack/Cypress/npm and add OpenAPI docs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -60,7 +60,7 @@ The dev container image is automatically built and published to GitHub Container
 - **`devcontainer.json`**: Main dev container configuration
 
   - Features: docker-outside-of-docker, git, common-utils (zsh/oh-my-zsh)
-  - Port forwarding: 3000 (Flood server), 4200 (webpack dev server), 6006 (Storybook)
+  - Port forwarding: 3000 (Flood server), 4200 (Vite dev server), 6006 (Storybook)
   - Volume mounts: `.docker`, `.ssh`, `.npmrc`, etc. (for credential sharing)
   - Cache: Pulls `ghcr.io/jesec/flood/devcontainer:latest` as build cache
 
@@ -77,8 +77,6 @@ The dev container image is automatically built and published to GitHub Container
 # Backend tests (spawns real torrent clients)
 pnpm run test
 
-# Frontend tests
-pnpm run test:client
 
 # Storybook tests
 pnpm run test-storybook

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Embedding is mainly for distribution and packaging, single deployable artifact, 
 - If embedded assets are present, Flood serves the UI from the embedded map.
   - Asset bodies are decoded from base64 to `Buffer` once at startup, then reused per request.
 - If embedded assets are not present, Flood serves static files from `dist/assets/`.
-  - In development, `dist/assets/index.html` may not exist (e.g. when using the webpack dev server); in that case the server won’t crash, and UI routes will return 404.
+  - In development, `dist/assets/index.html` may not exist (e.g. when using the Vite dev server); in that case the server won’t crash, and UI routes will return 404.
 
 ## Development tips
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ pnpm run test                        # Run tests to catch regressions
 ```bash
 # Package Manager: pnpm (v9.7.0) is the project's package manager
 pnpm install --frozen-lockfile  # Install dependencies with lockfile
-pnpm run build                   # Build production (esbuild for server, webpack for client)
+pnpm run build                   # Build production (esbuild for server, Vite for client)
 pnpm start                       # Start production server (node --enable-source-maps dist/index.js)
 pnpm start -- --port 8080       # With custom options (pass args after --)
 ```
@@ -56,7 +56,7 @@ pnpm start -- --port 8080       # With custom options (pass args after --)
 
 ```bash
 pnpm run start:development:server  # Server with tsx watch mode (hot reload via tsx watch)
-pnpm run start:development:client  # Client webpack-dev-server (port 4200, with Panda CSS watch)
+pnpm run start:development:client  # Client Vite dev server (port 4200, with Panda CSS watch)
 # Run both in separate terminals for full development environment
 ```
 
@@ -73,7 +73,7 @@ pnpm run start:development:client  # Client webpack-dev-server (port 4200, with 
 pnpm test                        # Run all Vitest integration tests (spawns real torrent clients!)
 pnpm test:watch                  # Watch mode with Vitest
 pnpm test -- --project rtorrent server/routes/api/torrents.test.ts  # Run a specific server test against rTorrent
-pnpm run test:client             # Cypress E2E tests (requires server on port 4200)
+pnpm run test-storybook          # Run Storybook interaction tests
 pnpm run test-storybook          # Run Storybook interaction tests
 
 # Test specific torrent clients (runs relevant Vitest project):
@@ -117,6 +117,15 @@ fastify.route({
 })
 ```
 
+### OpenAPI Documentation
+
+Flood provides an OpenAPI specification and interactive Swagger UI:
+
+- **OpenAPI spec**: Available at `/api/openapi.json`
+- **Swagger UI**: Interactive API documentation at `/api/docs/`
+- All endpoints are documented with Zod schemas that generate OpenAPI schemas
+- Uses `@fastify/swagger` with `fastify-type-provider-zod` for automatic schema generation
+
 ### Database: NeDB (Embedded)
 
 - Located in `~/.local/share/flood/` by default
@@ -127,7 +136,7 @@ fastify.route({
 ### Build Process
 
 - **Server**: esbuild bundles to single file (`dist/index.js`) with source maps
-- **Client**: webpack with code splitting, CSS extraction, asset optimization
+- **Client**: Vite with code splitting, CSS extraction, asset optimization
 - **Assets**: Static files copied to `dist/assets/`
 - **CSS**: Panda CSS generates styled-system via `panda codegen`
 
@@ -262,8 +271,6 @@ For reverse proxy setups:
 
 ### Development Environment Variables
 
-- `DEV_SERVER_PORT` - webpack-dev-server port (default: 4200)
-- `DEV_SERVER_HOST` - Dev server host (default: 0.0.0.0)
 - `NODE_ENV=development` - Enables dev features
 
 ## Common Development Tasks
@@ -308,7 +315,7 @@ For reverse proxy setups:
 
 - **TypeScript errors?** Run `pnpm run check-types` and fix from top to bottom
 - **Lint errors?** Run `pnpm run lint` - most are auto-fixable with `pnpm run format-source`
-- **Build fails?** Check both server (esbuild) and client (webpack) output
+- **Build fails?** Check both server (esbuild) and client (Vite) output
 - **Tests fail?** Run specific test file with `pnpm test -- path/to/test`
 - **Panda CSS issues?** Run `panda codegen` to regenerate styled-system
 
@@ -342,7 +349,7 @@ For reverse proxy setups:
 ```bash
 # Start both for full development:
 npm run start:development:server  # Backend on port 3000 (tsx watch mode)
-npm run start:development:client  # Frontend on port 4200 (webpack-dev-server)
+pnpm run start:development:client  # Frontend on port 4200 (Vite dev server)
 
 # Frontend proxies API calls to backend (configurable):
 npm run start:development:client -- --proxy http://localhost:3000
@@ -368,21 +375,33 @@ npm run test-storybook          # Run Storybook tests
 
 - Stories located in `client/src/javascript/components/**/*.stories.tsx`
 - Webpack aliases configured for `@client/` and `@shared/` paths
-- Full CSS module support matching production webpack config
+- Full CSS module support matching production Vite config
 - Babel decorators enabled for MobX compatibility
 
 ### Frontend Mocking Strategy
 
-#### 1. Action Mocking via Webpack NormalModuleReplacementPlugin
+#### 1. Action Mocking via Vite Plugin
 
-Storybook replaces real actions with mocks at build time:
+Storybook replaces real actions with mocks at build time using a custom Vite plugin in `.storybook/main.ts`:
 
 ```typescript
 // In .storybook/main.ts
-new webpack.NormalModuleReplacementPlugin(
-  /@client\/actions\/FloodActions$/,
-  path.resolve(__dirname, './mocks/FloodActions.ts'),
-);
+{
+  name: 'storybook-mock-action-modules',
+  enforce: 'pre',
+  resolveId(id: string, _importer: string | undefined) {
+    // Intercept @client/actions/* imports and redirect to mocks
+    const cleanId = id.split('?')[0];
+    for (const moduleName of MOCKED_ACTION_MODULES) {
+      const aliasPath = `@client/actions/${moduleName}`;
+      const realPath = path.resolve(realActionsDir, `${moduleName}.ts`);
+      if (cleanId === aliasPath || cleanId === realPath) {
+        return path.resolve(mockDir, `${moduleName}.ts`);
+      }
+    }
+    return undefined;
+  },
+}
 ```
 
 This ensures all imports of actions are replaced with mock implementations.

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ method.insert=d.down.sequential.set,value|const,0
 
 #### Integrating with Flood
 
-APIs are officially documented inline by the [comments](https://github.com/jesec/flood/blob/f7019001dd81ee8401c87d4c4cd6da6f5f520611/server/routes/api/torrents.ts#L106-L117) and [types](https://github.com/jesec/flood/blob/f7019001dd81ee8401c87d4c4cd6da6f5f520611/shared/schema/api/torrents.ts#L10-L32).
+Flood provides an OpenAPI specification and interactive Swagger UI for API documentation:
+
+- **OpenAPI spec**: Available at `/api/openapi.json`
+- **Swagger UI**: Interactive API documentation at `/api/docs/`
 
 You can also check out:
 
-- [community documentation site](https://flood-api.netlify.app)
 - [list of unofficial client API libraries](https://github.com/jesec/flood/wiki/List-of-unofficial-client-API-libraries)
 - [list of unofficial API integrations](https://github.com/jesec/flood/wiki/List-of-unofficial-API-integrations)
 
@@ -139,40 +141,34 @@ Filesystem parts in [Troubleshooting](https://github.com/jesec/flood#troubleshoo
 
 From the root of the Flood directory...
 
-1. Run `npm install`.
-1. Run `npm run build`.
-1. Run `npm start`.
+1. Run `pnpm install`.
+1. Run `pnpm run build`.
+1. Run `pnpm start`.
 
 Access the UI in your browser. With default settings, go to `http://localhost:3000`. You can configure the port via `--port` argument.
 
 **Notes**
 
-- When you use `npm run start` to execute Flood, you have to pass command line arguments after `--`. For example, `npm run start -- --host 0.0.0.0 --port 8080`. This applies to any `npm run` (e.g. `start:development:client`).
+- When you use `pnpm run start` to execute Flood, you have to pass command line arguments after `--`. For example, `pnpm run start -- --host 0.0.0.0 --port 8080`. This applies to any `pnpm run` (e.g. `start:development:client`).
 
 ### Updating
 
 1. To update, run `git pull` in this repository's directory.
 1. Kill the currently running Flood server.
-1. Run `npm install` to update dependencies.
-1. Run `npm run build` to transpile and bundle static assets.
-1. Start the Flood server with `npm start`.
+1. Run `pnpm install` to update dependencies.
+1. Run `pnpm run build` to transpile and bundle static assets.
+1. Start the Flood server with `pnpm start`.
 
 ### Local Development
 
-1. Run `npm install`.
-1. Run `npm run start:development:server` and `npm run start:development:client` in separate terminal instances.
-   - `npm run start:development:server` uses [ts-node-dev](https://www.npmjs.com/package/ts-node-dev) to watch for changes to the server-side source. Or open the folder with VS code and then `Run -> Start Debugging`. You may use a [Javascript IDE](https://code.visualstudio.com/) to debug server codes.
-   - `npm run start:development:client` watches for changes in the client-side source. Access the UI in your browser. Defaults to `localhost:4200`. You may use browser's [DevTools](https://developers.google.com/web/tools/chrome-devtools) to debug client codes.
+1. Run `pnpm install`.
+1. Run `pnpm run start:development:server` and `pnpm run start:development:client` in separate terminal instances.
+   - `pnpm run start:development:server` uses [tsx](https://www.npmjs.com/package/tsx) to watch for changes to the server-side source. Or open the folder with VS code and then `Run -> Start Debugging`. You may use a [Javascript IDE](https://code.visualstudio.com/) to debug server codes.
+   - `pnpm run start:development:client` watches for changes in the client-side source. Access the UI in your browser. Defaults to `localhost:4200`. You may use browser's [DevTools](https://developers.google.com/web/tools/chrome-devtools) to debug client codes.
 
 `--help --show-hidden` shows advanced arguments.
 
 `--proxy` proxies requests from a development client to a URL of your choice (usually URL to a Flood server). It is useful when you wish to do development on the frontend but not the backend. Or when the frontend and backend are being developed on different hosts.
-
-### Environment Variables
-
-1. `DEV_SERVER_PORT`: webpackDevServer's port, used when developing Flood. Defaults to `4200`.
-1. `DEV_SERVER_HOST`: webpackDevServer's host, used when developing Flood. Defaults to `0.0.0.0`.
-1. `DEV_SERVER_HTTPS`: webpackDevServer's protocol, used when developing Flood. Defaults to `http`.
 
 ### Building Docker
 


### PR DESCRIPTION
Updates documentation to reflect current tooling:
- Replace webpack references with Vite
- Replace npm with pnpm
- Remove Cypress E2E references (no longer used)
- Remove stale DEV_SERVER_* env vars
- Add OpenAPI/Swagger UI documentation