### PR TITLE
refactor: convert ClientGatewayService to interface with async factory pattern

### DIFF
--- a/server/routes/api/auth.ts
+++ b/server/routes/api/auth.ts
@@ -164,7 +164,7 @@ const authRoutes = async (fastify: FastifyInstance) => {
       const credentials = req.body;
 
       const user = await Users.createUser(credentials);
-      bootstrapServicesForUser(user);
+      await bootstrapServicesForUser(user);
 
       if (req.query.cookie === 'false') {
         return {username: user.username};
@@ -358,7 +358,7 @@ const authRoutes = async (fastify: FastifyInstance) => {
 
           await destroyUserServices(user._id);
 
-          bootstrapServicesForUser(user);
+          await bootstrapServicesForUser(user);
 
           return {};
         },

--- a/server/services/Deluge/clientGatewayService.ts
+++ b/server/services/Deluge/clientGatewayService.ts
@@ -7,6 +7,7 @@ import type {
   ReannounceTorrentsOptions,
   SetTorrentsTagsOptions,
 } from '@shared/schema/api/torrents';
+import type {UserInDatabase} from '@shared/schema/Auth';
 import type {DelugeConnectionSettings} from '@shared/schema/ClientConnectionSettings';
 import type {SetClientSettingsOptions} from '@shared/types/api/client';
 import type {
@@ -31,13 +32,23 @@ import {TorrentTrackerType} from '@shared/types/TorrentTracker';
 import type {TransferSummary} from '@shared/types/TransferData';
 
 import {fetchUrls} from '../../util/fetchUtil';
-import ClientGatewayService from '../clientGatewayService';
+import BaseClientGatewayService, {type ClientGatewayService} from '../clientGatewayService';
 import ClientRequestManager from './clientRequestManager';
 import {DelugeCoreTorrentFilePriority} from './types/DelugeCoreMethods';
 import {getTorrentStatusFromStatuses} from './util/torrentPropertiesUtil';
 
-class DelugeClientGatewayService extends ClientGatewayService {
-  private clientRequestManager = new ClientRequestManager(this.user.client as DelugeConnectionSettings);
+class DelugeClientGatewayService extends BaseClientGatewayService implements ClientGatewayService {
+  private clientRequestManager: ClientRequestManager;
+
+  constructor(user: UserInDatabase, clientRequestManager: ClientRequestManager) {
+    super(user);
+    this.clientRequestManager = clientRequestManager;
+  }
+
+  static async create(user: UserInDatabase): Promise<DelugeClientGatewayService> {
+    const clientRequestManager = new ClientRequestManager(user.client as DelugeConnectionSettings);
+    return new DelugeClientGatewayService(user, clientRequestManager);
+  }
 
   async addTorrentsByFile({
     files,

--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -6,6 +6,7 @@ import type {
   ReannounceTorrentsOptions,
   SetTorrentsTagsOptions,
 } from '@shared/schema/api/torrents';
+import type {UserInDatabase} from '@shared/schema/Auth';
 import type {TransmissionConnectionSettings} from '@shared/schema/ClientConnectionSettings';
 import type {SetClientSettingsOptions} from '@shared/types/api/client';
 import type {
@@ -30,14 +31,24 @@ import {TorrentContentPriority} from '../../../shared/types/TorrentContent';
 import {TorrentTrackerType} from '../../../shared/types/TorrentTracker';
 import {fetchUrls} from '../../util/fetchUtil';
 import {getDomainsFromURLs} from '../../util/torrentPropertiesUtil';
-import ClientGatewayService from '../clientGatewayService';
+import BaseClientGatewayService, {type ClientGatewayService} from '../clientGatewayService';
 import * as geoip from '../geoip';
 import ClientRequestManager from './clientRequestManager';
 import {TransmissionPriority, TransmissionTorrentsSetArguments} from './types/TransmissionTorrentsMethods';
 import torrentPropertiesUtil from './util/torrentPropertiesUtil';
 
-class TransmissionClientGatewayService extends ClientGatewayService {
-  clientRequestManager = new ClientRequestManager(this.user.client as TransmissionConnectionSettings);
+class TransmissionClientGatewayService extends BaseClientGatewayService implements ClientGatewayService {
+  clientRequestManager: ClientRequestManager;
+
+  constructor(user: UserInDatabase, clientRequestManager: ClientRequestManager) {
+    super(user);
+    this.clientRequestManager = clientRequestManager;
+  }
+
+  static async create(user: UserInDatabase): Promise<TransmissionClientGatewayService> {
+    const clientRequestManager = new ClientRequestManager(user.client as TransmissionConnectionSettings);
+    return new TransmissionClientGatewayService(user, clientRequestManager);
+  }
 
   async addTorrentsByFile({
     files,

--- a/server/services/clientGatewayService.ts
+++ b/server/services/clientGatewayService.ts
@@ -24,8 +24,10 @@ import type {TorrentContent} from '@shared/types/TorrentContent';
 import type {TorrentPeer} from '@shared/types/TorrentPeer';
 import type {TorrentTracker} from '@shared/types/TorrentTracker';
 import type {TransferSummary} from '@shared/types/TransferData';
+import type TypedEmitter from 'typed-emitter';
 
 import config from '../../config';
+import type {ServiceInstances} from '.';
 import BaseService from './BaseService';
 
 type ClientGatewayServiceEvents = {
@@ -35,9 +37,9 @@ type ClientGatewayServiceEvents = {
   PROCESS_TORRENT: (torrentProperties: TorrentProperties) => void;
 };
 
-abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEvents> {
-  errorCount = 0;
-  retryTimer?: NodeJS.Timeout | null = null;
+export interface ClientGatewayService extends TypedEmitter<ClientGatewayServiceEvents> {
+  errorCount: number;
+  retryTimer?: NodeJS.Timeout | null;
 
   /**
    * Adds torrents by file
@@ -45,7 +47,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Resolves with an array of hashes of added torrents or rejects with error.
    */
-  abstract addTorrentsByFile(options: Required<AddTorrentByFileOptions>): Promise<string[]>;
+  addTorrentsByFile(options: Required<AddTorrentByFileOptions>): Promise<string[]>;
 
   /**
    * Adds torrents by URL
@@ -53,7 +55,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Resolves with an array of hashes of added torrents or rejects with error.
    */
-  abstract addTorrentsByURL(options: Required<AddTorrentByURLOptions>): Promise<string[]>;
+  addTorrentsByURL(options: Required<AddTorrentByURLOptions>): Promise<string[]>;
 
   /**
    * Checks torrents
@@ -61,7 +63,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract checkTorrents({hashes}: CheckTorrentsOptions): Promise<void>;
+  checkTorrents({hashes}: CheckTorrentsOptions): Promise<void>;
 
   /**
    * Gets the list of contents of a torrent.
@@ -69,7 +71,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param hash - Hash of torrent
    * @return - Resolves with TorrentContentTree or rejects with error.
    */
-  abstract getTorrentContents(hash: TorrentProperties['hash']): Promise<Array<TorrentContent>>;
+  getTorrentContents(hash: TorrentProperties['hash']): Promise<Array<TorrentContent>>;
 
   /**
    * Gets the list of peers of a torrent.
@@ -77,7 +79,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param hash - Hash of torrent
    * @return - Resolves with an array of TorrentPeer or rejects with error.
    */
-  abstract getTorrentPeers(hash: TorrentProperties['hash']): Promise<Array<TorrentPeer>>;
+  getTorrentPeers(hash: TorrentProperties['hash']): Promise<Array<TorrentPeer>>;
 
   /**
    * Gets the list of trackers of a torrent.
@@ -85,7 +87,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param hash - Hash of torrent
    * @return - Resolves with an array of TorrentTracker or rejects with error.
    */
-  abstract getTorrentTrackers(hash: TorrentProperties['hash']): Promise<Array<TorrentTracker>>;
+  getTorrentTrackers(hash: TorrentProperties['hash']): Promise<Array<TorrentTracker>>;
 
   /**
    * Moves torrents to specified destination path.
@@ -93,7 +95,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract moveTorrents(options: MoveTorrentsOptions): Promise<void>;
+  moveTorrents(options: MoveTorrentsOptions): Promise<void>;
 
   /**
    * Reannounces torrents to trackers
@@ -101,7 +103,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract reannounceTorrents({hashes}: ReannounceTorrentsOptions): Promise<void>;
+  reannounceTorrents({hashes}: ReannounceTorrentsOptions): Promise<void>;
 
   /**
    * Removes torrents. Optionally deletes data of torrents.
@@ -109,7 +111,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract removeTorrents(options: DeleteTorrentsOptions): Promise<void>;
+  removeTorrents(options: DeleteTorrentsOptions): Promise<void>;
 
   /**
    * Sets initial seeding mode of torrents
@@ -117,7 +119,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract setTorrentsInitialSeeding(options: SetTorrentsInitialSeedingOptions): Promise<void>;
+  setTorrentsInitialSeeding(options: SetTorrentsInitialSeedingOptions): Promise<void>;
 
   /**
    * Sets priority of torrents
@@ -125,7 +127,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract setTorrentsPriority(options: SetTorrentsPriorityOptions): Promise<void>;
+  setTorrentsPriority(options: SetTorrentsPriorityOptions): Promise<void>;
 
   /**
    * Sets sequential mode of torrents
@@ -133,7 +135,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract setTorrentsSequential(options: SetTorrentsSequentialOptions): Promise<void>;
+  setTorrentsSequential(options: SetTorrentsSequentialOptions): Promise<void>;
 
   /**
    * Sets tags of torrents
@@ -141,7 +143,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract setTorrentsTags(options: SetTorrentsTagsOptions): Promise<void>;
+  setTorrentsTags(options: SetTorrentsTagsOptions): Promise<void>;
 
   /**
    * Sets trackers of torrents
@@ -149,7 +151,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract setTorrentsTrackers(options: SetTorrentsTrackersOptions): Promise<void>;
+  setTorrentsTrackers(options: SetTorrentsTrackersOptions): Promise<void>;
 
   /**
    * Sets priority of contents of a torrent
@@ -158,7 +160,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract setTorrentContentsPriority(hash: string, options: SetTorrentContentsPropertiesOptions): Promise<void>;
+  setTorrentContentsPriority(hash: string, options: SetTorrentContentsPropertiesOptions): Promise<void>;
 
   /**
    * Starts torrents
@@ -166,7 +168,7 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract startTorrents(options: StartTorrentsOptions): Promise<void>;
+  startTorrents(options: StartTorrentsOptions): Promise<void>;
 
   /**
    * Stops torrents
@@ -174,35 +176,35 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param options - An object of options...
    * @return - Rejects with error.
    */
-  abstract stopTorrents(options: StopTorrentsOptions): Promise<void>;
+  stopTorrents(options: StopTorrentsOptions): Promise<void>;
 
   /**
    * Fetches the list of torrents
    *
    * @return - Resolves with TorrentListSummary or rejects with error.
    */
-  abstract fetchTorrentList(): Promise<TorrentListSummary>;
+  fetchTorrentList(): Promise<TorrentListSummary>;
 
   /**
    * Fetches the transfer summary
    *
    * @return - Resolves with TransferSummary or rejects with error.
    */
-  abstract fetchTransferSummary(): Promise<TransferSummary>;
+  fetchTransferSummary(): Promise<TransferSummary>;
 
   /**
    * Gets session directory (where .torrent files are stored) of the torrent client
    *
    * @return - Resolves with path of session directory or rejects with error.
    */
-  abstract getClientSessionDirectory(): Promise<{path: string; case: 'lower' | 'upper'}>;
+  getClientSessionDirectory(): Promise<{path: string; case: 'lower' | 'upper'}>;
 
   /**
    * Gets settings of the torrent client
    *
    * @return - Resolves with ClientSettings or rejects with error.
    */
-  abstract getClientSettings(): Promise<ClientSettings>;
+  getClientSettings(): Promise<ClientSettings>;
 
   /**
    * Sets settings of the torrent client
@@ -210,17 +212,25 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
    * @param settings - Settings to be set.
    * @return - Rejects with error.
    */
-  abstract setClientSettings(settings: SetClientSettingsOptions): Promise<void>;
+  setClientSettings(settings: SetClientSettingsOptions): Promise<void>;
 
-  abstract testGateway(): Promise<void>;
+  testGateway(): Promise<void>;
 
-  constructor(user: UserInDatabase) {
-    super(user);
+  destroyTimer(): void;
+  destroy(drop: boolean): Promise<void>;
+  startTimer(): void;
+  processClientRequestSuccess: <T>(response: T) => T;
+  processClientRequestError: (error: Error) => never;
+  user: UserInDatabase;
+  services?: ServiceInstances;
+  updateServices(service?: ServiceInstances): void;
+  updateUser(user: UserInDatabase): void;
+  onServicesUpdated: () => void;
+}
 
-    this.testGateway()
-      .then(this.processClientRequestSuccess, this.processClientRequestError)
-      .catch(() => undefined);
-  }
+abstract class BaseClientGatewayService extends BaseService<ClientGatewayServiceEvents> {
+  errorCount = 0;
+  retryTimer?: NodeJS.Timeout | null = null;
 
   destroyTimer() {
     if (this.retryTimer != null) {
@@ -267,6 +277,8 @@ abstract class ClientGatewayService extends BaseService<ClientGatewayServiceEven
 
     throw error;
   };
+
+  abstract testGateway(): Promise<void>;
 }
 
-export default ClientGatewayService;
+export default BaseClientGatewayService;

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,6 +1,6 @@
 import type {UserInDatabase} from '@shared/schema/Auth';
 
-import ClientGatewayService from './clientGatewayService';
+import {type ClientGatewayService} from './clientGatewayService';
 import DelugeClientGatewayService from './Deluge/clientGatewayService';
 import FeedService from './feedService';
 import HistoryService from './historyService';
@@ -25,18 +25,18 @@ export interface ServiceInstances {
 
 const serviceInstances: Record<string, ServiceInstances> = {};
 
-const newClientGatewayService = (user: UserInDatabase): ClientGatewayService => {
+const newClientGatewayService = async (user: UserInDatabase): Promise<ClientGatewayService> => {
   switch (user.client.client) {
     case 'Deluge':
-      return new DelugeClientGatewayService(user);
+      return DelugeClientGatewayService.create(user);
     case 'Neptune':
       return new NeptuneClientGatewayService(user);
     case 'qBittorrent':
-      return new QBittorrentClientGatewayService(user);
+      return QBittorrentClientGatewayService.create(user);
     case 'rTorrent':
-      return new RTorrentClientGatewayService(user);
+      return RTorrentClientGatewayService.create(user);
     case 'Transmission':
-      return new TransmissionClientGatewayService(user);
+      return TransmissionClientGatewayService.create(user);
   }
 };
 
@@ -56,7 +56,7 @@ export const destroyUserServices = async (userId: UserInDatabase['_id'], drop = 
   );
 };
 
-export const bootstrapServicesForUser = (user: UserInDatabase) => {
+export const bootstrapServicesForUser = async (user: UserInDatabase) => {
   const {_id} = user;
 
   if (serviceInstances[_id] != null) {
@@ -64,7 +64,7 @@ export const bootstrapServicesForUser = (user: UserInDatabase) => {
   }
 
   const userServiceInstances = {
-    clientGatewayService: newClientGatewayService(user),
+    clientGatewayService: await newClientGatewayService(user),
     feedService: new FeedService(user),
     historyService: new HistoryService(user),
     notificationService: new NotificationService(user),

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,6 +1,6 @@
 import type {UserInDatabase} from '@shared/schema/Auth';
 
-import ClientGatewayService from './clientGatewayService';
+import {type ClientGatewayService} from './clientGatewayService';
 import DelugeClientGatewayService from './Deluge/clientGatewayService';
 import FeedService from './feedService';
 import HistoryService from './historyService';
@@ -24,16 +24,16 @@ export interface ServiceInstances {
 
 const serviceInstances: Record<string, ServiceInstances> = {};
 
-const newClientGatewayService = (user: UserInDatabase): ClientGatewayService => {
+const newClientGatewayService = async (user: UserInDatabase): Promise<ClientGatewayService> => {
   switch (user.client.client) {
     case 'Deluge':
-      return new DelugeClientGatewayService(user);
+      return DelugeClientGatewayService.create(user);
     case 'qBittorrent':
-      return new QBittorrentClientGatewayService(user);
+      return QBittorrentClientGatewayService.create(user);
     case 'rTorrent':
-      return new RTorrentClientGatewayService(user);
+      return RTorrentClientGatewayService.create(user);
     case 'Transmission':
-      return new TransmissionClientGatewayService(user);
+      return TransmissionClientGatewayService.create(user);
   }
 };
 
@@ -53,7 +53,7 @@ export const destroyUserServices = async (userId: UserInDatabase['_id'], drop = 
   );
 };
 
-export const bootstrapServicesForUser = (user: UserInDatabase) => {
+export const bootstrapServicesForUser = async (user: UserInDatabase) => {
   const {_id} = user;
 
   if (serviceInstances[_id] != null) {
@@ -61,7 +61,7 @@ export const bootstrapServicesForUser = (user: UserInDatabase) => {
   }
 
   const userServiceInstances = {
-    clientGatewayService: newClientGatewayService(user),
+    clientGatewayService: await newClientGatewayService(user),
     feedService: new FeedService(user),
     historyService: new HistoryService(user),
     notificationService: new NotificationService(user),

--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -8,6 +8,7 @@ import type {
   ReannounceTorrentsOptions,
   SetTorrentsTagsOptions,
 } from '@shared/schema/api/torrents';
+import type {UserInDatabase} from '@shared/schema/Auth';
 import type {QBittorrentConnectionSettings} from '@shared/schema/ClientConnectionSettings';
 import type {SetClientSettingsOptions} from '@shared/types/api/client';
 import type {
@@ -35,7 +36,7 @@ import {TorrentContentPriority} from '../../../shared/types/TorrentContent';
 import {TorrentTrackerType} from '../../../shared/types/TorrentTracker';
 import {fetchUrls} from '../../util/fetchUtil';
 import {getDomainsFromURLs} from '../../util/torrentPropertiesUtil';
-import ClientGatewayService from '../clientGatewayService';
+import BaseClientGatewayService, {type ClientGatewayService} from '../clientGatewayService';
 import ClientRequestManager from './clientRequestManager';
 import {QBittorrentTorrentContentPriority, QBittorrentTorrentTrackerStatus} from './types/QBittorrentTorrentsMethods';
 import {isApiVersionAtLeast} from './util/apiVersionCheck';
@@ -45,8 +46,8 @@ import {
   getTorrentTrackerTypeFromURL,
 } from './util/torrentPropertiesUtil';
 
-class QBittorrentClientGatewayService extends ClientGatewayService {
-  private clientRequestManager = new ClientRequestManager(this.user.client as QBittorrentConnectionSettings);
+class QBittorrentClientGatewayService extends BaseClientGatewayService implements ClientGatewayService {
+  private clientRequestManager: ClientRequestManager;
   private cachedProperties: Record<
     string,
     Pick<TorrentProperties, 'comment' | 'dateCreated' | 'isPrivate' | 'trackerURIs'> & {
@@ -54,6 +55,16 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
       trackerMessageFetchedAt: number;
     }
   > = {};
+
+  constructor(user: UserInDatabase, clientRequestManager: ClientRequestManager) {
+    super(user);
+    this.clientRequestManager = clientRequestManager;
+  }
+
+  static async create(user: UserInDatabase): Promise<QBittorrentClientGatewayService> {
+    const clientRequestManager = new ClientRequestManager(user.client as QBittorrentConnectionSettings);
+    return new QBittorrentClientGatewayService(user, clientRequestManager);
+  }
 
   private async fetchProperties(hash: string, includeProperties: boolean): Promise<void> {
     const properties = includeProperties

--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -8,6 +8,7 @@ import type {
   ReannounceTorrentsOptions,
   SetTorrentsTagsOptions,
 } from '@shared/schema/api/torrents';
+import type {UserInDatabase} from '@shared/schema/Auth';
 import type {QBittorrentConnectionSettings} from '@shared/schema/ClientConnectionSettings';
 import type {SetClientSettingsOptions} from '@shared/types/api/client';
 import type {
@@ -35,7 +36,7 @@ import {TorrentContentPriority} from '../../../shared/types/TorrentContent';
 import {TorrentTrackerType} from '../../../shared/types/TorrentTracker';
 import {fetchUrls} from '../../util/fetchUtil';
 import {getDomainsFromURLs} from '../../util/torrentPropertiesUtil';
-import ClientGatewayService from '../clientGatewayService';
+import BaseClientGatewayService, {type ClientGatewayService} from '../clientGatewayService';
 import ClientRequestManager from './clientRequestManager';
 import {QBittorrentTorrentContentPriority, QBittorrentTorrentTrackerStatus} from './types/QBittorrentTorrentsMethods';
 import {isApiVersionAtLeast} from './util/apiVersionCheck';
@@ -45,14 +46,24 @@ import {
   getTorrentTrackerTypeFromURL,
 } from './util/torrentPropertiesUtil';
 
-class QBittorrentClientGatewayService extends ClientGatewayService {
-  private clientRequestManager = new ClientRequestManager(this.user.client as QBittorrentConnectionSettings);
+class QBittorrentClientGatewayService extends BaseClientGatewayService implements ClientGatewayService {
+  private clientRequestManager: ClientRequestManager;
   private cachedProperties: Record<
     string,
     Pick<TorrentProperties, 'comment' | 'dateCreated' | 'isPrivate' | 'trackerURIs'> & {
       trackerMessage: string;
     }
   > = {};
+
+  constructor(user: UserInDatabase, clientRequestManager: ClientRequestManager) {
+    super(user);
+    this.clientRequestManager = clientRequestManager;
+  }
+
+  static async create(user: UserInDatabase): Promise<QBittorrentClientGatewayService> {
+    const clientRequestManager = new ClientRequestManager(user.client as QBittorrentConnectionSettings);
+    return new QBittorrentClientGatewayService(user, clientRequestManager);
+  }
 
   async addTorrentsByFile({
     files,

--- a/server/services/rTorrent/clientGatewayService.ts
+++ b/server/services/rTorrent/clientGatewayService.ts
@@ -7,6 +7,7 @@ import type {
   ReannounceTorrentsOptions,
   SetTorrentsTagsOptions,
 } from '@shared/schema/api/torrents';
+import type {UserInDatabase} from '@shared/schema/Auth';
 import type {RTorrentConnectionSettings} from '@shared/schema/ClientConnectionSettings';
 import type {SetClientSettingsOptions} from '@shared/types/api/client';
 import type {
@@ -33,7 +34,7 @@ import sanitize from 'sanitize-filename';
 import {fetchUrls} from '../../util/fetchUtil';
 import {cleanupEmptyDirectories, isAllowedPath, sanitizePath} from '../../util/fileUtil';
 import {getComment, setCompleted, setTrackers} from '../../util/torrentFileUtil';
-import ClientGatewayService from '../clientGatewayService';
+import BaseClientGatewayService, {type ClientGatewayService} from '../clientGatewayService';
 import * as geoip from '../geoip';
 import ClientRequestManager from './clientRequestManager';
 import {
@@ -55,14 +56,90 @@ import {
   getTorrentStatusFromProperties,
 } from './util/torrentPropertiesUtil';
 
-class RTorrentClientGatewayService extends ClientGatewayService {
-  clientRequestManager = new ClientRequestManager(this.user.client as RTorrentConnectionSettings);
-  availableMethodCalls = this.fetchAvailableMethodCalls();
+type AvailableMethodCalls = {
+  methodList: string[];
+  clientSetting: string[];
+  torrentContent: string[];
+  torrentList: string[];
+  torrentPeer: string[];
+  torrentTracker: string[];
+  transferSummary: string[];
+};
+
+const EMPTY_METHOD_CALLS: AvailableMethodCalls = {
+  methodList: [],
+  clientSetting: [],
+  torrentContent: [],
+  torrentList: [],
+  torrentPeer: [],
+  torrentTracker: [],
+  transferSummary: [],
+};
+
+async function fetchAvailableMethodCalls(
+  clientRequestManager: ClientRequestManager,
+  fallback = false,
+): Promise<AvailableMethodCalls> {
+  let methodList: Array<string> = [];
+
+  clientRequestManager.isJSONCapable = true;
+  methodList = await clientRequestManager.methodCall('system.listMethods', []).catch((e: RPCError) => {
+    if (e.isRPCError || e.name == 'SyntaxError') {
+      clientRequestManager.isJSONCapable = false;
+    } else if (!fallback) {
+      throw e;
+    }
+  });
+
+  if (!clientRequestManager.isJSONCapable) {
+    methodList = await clientRequestManager.methodCall('system.listMethods', []).catch((e) => {
+      if (!fallback) {
+        throw e;
+      }
+    });
+  }
+
+  const getAvailableMethodCalls =
+    methodList?.length > 0
+      ? (methodCalls: Array<string>) => {
+          return methodCalls.map((method) => (methodList.includes(method.split('=')[0]) ? method : 'false='));
+        }
+      : (methodCalls: Array<string>) => methodCalls;
+
+  return {
+    methodList,
+    clientSetting: getAvailableMethodCalls(getMethodCalls(clientSettingMethodCallConfigs)),
+    torrentContent: getAvailableMethodCalls(getMethodCalls(torrentContentMethodCallConfigs)),
+    torrentList: getAvailableMethodCalls(getMethodCalls(torrentListMethodCallConfigs)),
+    torrentPeer: getAvailableMethodCalls(getMethodCalls(torrentPeerMethodCallConfigs)),
+    torrentTracker: getAvailableMethodCalls(getMethodCalls(torrentTrackerMethodCallConfigs)),
+    transferSummary: getAvailableMethodCalls(getMethodCalls(transferSummaryMethodCallConfigs)),
+  };
+}
+
+class RTorrentClientGatewayService extends BaseClientGatewayService implements ClientGatewayService {
+  clientRequestManager: ClientRequestManager;
+  availableMethodCalls: AvailableMethodCalls;
+
+  constructor(user: UserInDatabase, availableMethodCalls: AvailableMethodCalls) {
+    super(user);
+    this.clientRequestManager = new ClientRequestManager(user.client as RTorrentConnectionSettings);
+    this.availableMethodCalls = availableMethodCalls;
+  }
+
+  static async create(user: UserInDatabase): Promise<RTorrentClientGatewayService> {
+    const clientRequestManager = new ClientRequestManager(user.client as RTorrentConnectionSettings);
+    let availableMethodCalls = await fetchAvailableMethodCalls(clientRequestManager).catch(() => null);
+    if (availableMethodCalls == null) {
+      availableMethodCalls = EMPTY_METHOD_CALLS;
+    }
+    return new RTorrentClientGatewayService(user, availableMethodCalls);
+  }
 
   // workaround: rTorrent instances might reject large d.multicall2 JSON-RPC requests
   // even though the equivalent XML-RPC call succeeds. rakshasa/rtorrent#1596
   private async fetchTorrentListResponses() {
-    const methodCalls = ['', 'main'].concat((await this.availableMethodCalls).torrentList);
+    const methodCalls = ['', 'main'].concat(this.availableMethodCalls.torrentList);
 
     try {
       return await this.clientRequestManager
@@ -81,7 +158,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async getPreferredMethod(methods: string[]): Promise<string> {
-    const {methodList} = await this.availableMethodCalls;
+    const {methodList} = this.availableMethodCalls;
 
     const matchedMethod = methods.find((method) => methodList.includes(method));
 
@@ -261,7 +338,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
 
   async getTorrentContents(hash: TorrentProperties['hash']): Promise<Array<TorrentContent>> {
     return this.clientRequestManager
-      .methodCall('f.multicall', [hash, ''].concat((await this.availableMethodCalls).torrentContent))
+      .methodCall('f.multicall', [hash, ''].concat(this.availableMethodCalls.torrentContent))
       .then(this.processClientRequestSuccess, this.processRTorrentRequestError)
       .then((responses: string[][]) => {
         return Promise.all(
@@ -284,7 +361,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
 
   async getTorrentPeers(hash: TorrentProperties['hash']): Promise<Array<TorrentPeer>> {
     return this.clientRequestManager
-      .methodCall('p.multicall', [hash, ''].concat((await this.availableMethodCalls).torrentPeer))
+      .methodCall('p.multicall', [hash, ''].concat(this.availableMethodCalls.torrentPeer))
       .then(this.processClientRequestSuccess, this.processRTorrentRequestError)
       .then((responses: string[][]) => {
         return Promise.all(
@@ -305,7 +382,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
 
   async getTorrentTrackers(hash: TorrentProperties['hash']): Promise<Array<TorrentTracker>> {
     return this.clientRequestManager
-      .methodCall('t.multicall', [hash, ''].concat((await this.availableMethodCalls).torrentTracker))
+      .methodCall('t.multicall', [hash, ''].concat(this.availableMethodCalls.torrentTracker))
       .then(this.processClientRequestSuccess, this.processRTorrentRequestError)
       .then((responses: string[][]) => {
         return Promise.all(
@@ -543,7 +620,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async setTorrentsSequential({hashes, isSequential}: SetTorrentsSequentialOptions): Promise<void> {
-    const {methodList} = await this.availableMethodCalls;
+    const {methodList} = this.availableMethodCalls;
 
     if (!methodList.includes('d.down.sequential.set')) {
       throw new Error('d.down.sequential.set is not supported by this rTorrent instance');
@@ -761,7 +838,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async fetchTransferSummary(): Promise<TransferSummary> {
-    const methodCalls: MultiMethodCalls = (await this.availableMethodCalls).transferSummary.map((methodCall) => {
+    const methodCalls: MultiMethodCalls = this.availableMethodCalls.transferSummary.map((methodCall) => {
       return {
         methodName: methodCall,
         params: [''],
@@ -784,7 +861,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async getClientSettings(): Promise<ClientSettings> {
-    const methodCalls: MultiMethodCalls = (await this.availableMethodCalls).clientSetting.map((methodCall) => {
+    const methodCalls: MultiMethodCalls = this.availableMethodCalls.clientSetting.map((methodCall) => {
       return {
         methodName: methodCall,
         params: [''],
@@ -845,59 +922,9 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async testGateway(): Promise<void> {
-    const availableMethodCalls = await this.fetchAvailableMethodCalls();
-    this.availableMethodCalls = Promise.resolve(availableMethodCalls);
-  }
-
-  async fetchAvailableMethodCalls(fallback = false): Promise<{
-    methodList: string[];
-    clientSetting: string[];
-    torrentContent: string[];
-    torrentList: string[];
-    torrentPeer: string[];
-    torrentTracker: string[];
-    transferSummary: string[];
-  }> {
-    let methodList: Array<string> = [];
-    const listMethods = () => {
-      return this.clientRequestManager
-        .methodCall('system.listMethods', [])
-        .then(this.processClientRequestSuccess, this.processRTorrentRequestError);
-    };
-
-    this.clientRequestManager.isJSONCapable = true;
-    methodList = await listMethods().catch((e: RPCError) => {
-      if (e.isRPCError || e.name == 'SyntaxError') {
-        this.clientRequestManager.isJSONCapable = false;
-      } else if (!fallback) {
-        throw e;
-      }
-    });
-
-    if (!this.clientRequestManager.isJSONCapable) {
-      methodList = await listMethods().catch((e) => {
-        if (!fallback) {
-          throw e;
-        }
-      });
-    }
-
-    const getAvailableMethodCalls =
-      methodList?.length > 0
-        ? (methodCalls: Array<string>) => {
-            return methodCalls.map((method) => (methodList.includes(method.split('=')[0]) ? method : 'false='));
-          }
-        : (methodCalls: Array<string>) => methodCalls;
-
-    return {
-      methodList,
-      clientSetting: getAvailableMethodCalls(getMethodCalls(clientSettingMethodCallConfigs)),
-      torrentContent: getAvailableMethodCalls(getMethodCalls(torrentContentMethodCallConfigs)),
-      torrentList: getAvailableMethodCalls(getMethodCalls(torrentListMethodCallConfigs)),
-      torrentPeer: getAvailableMethodCalls(getMethodCalls(torrentPeerMethodCallConfigs)),
-      torrentTracker: getAvailableMethodCalls(getMethodCalls(torrentTrackerMethodCallConfigs)),
-      transferSummary: getAvailableMethodCalls(getMethodCalls(transferSummaryMethodCallConfigs)),
-    };
+    this.availableMethodCalls = this.processClientRequestSuccess(
+      await fetchAvailableMethodCalls(this.clientRequestManager).catch(this.processRTorrentRequestError),
+    );
   }
 
   processRTorrentRequestError = (error: RPCError) => {

--- a/server/services/rTorrent/clientGatewayService.ts
+++ b/server/services/rTorrent/clientGatewayService.ts
@@ -7,6 +7,7 @@ import type {
   ReannounceTorrentsOptions,
   SetTorrentsTagsOptions,
 } from '@shared/schema/api/torrents';
+import type {UserInDatabase} from '@shared/schema/Auth';
 import type {RTorrentConnectionSettings} from '@shared/schema/ClientConnectionSettings';
 import type {SetClientSettingsOptions} from '@shared/types/api/client';
 import type {
@@ -33,7 +34,7 @@ import sanitize from 'sanitize-filename';
 import {fetchUrls} from '../../util/fetchUtil';
 import {cleanupEmptyDirectories, isAllowedPath, sanitizePath} from '../../util/fileUtil';
 import {getComment, setCompleted, setTrackers} from '../../util/torrentFileUtil';
-import ClientGatewayService from '../clientGatewayService';
+import BaseClientGatewayService, {type ClientGatewayService} from '../clientGatewayService';
 import * as geoip from '../geoip';
 import ClientRequestManager from './clientRequestManager';
 import {
@@ -55,14 +56,90 @@ import {
   getTorrentStatusFromProperties,
 } from './util/torrentPropertiesUtil';
 
-class RTorrentClientGatewayService extends ClientGatewayService {
-  clientRequestManager = new ClientRequestManager(this.user.client as RTorrentConnectionSettings);
-  availableMethodCalls = this.fetchAvailableMethodCalls();
+type AvailableMethodCalls = {
+  methodList: string[];
+  clientSetting: string[];
+  torrentContent: string[];
+  torrentList: string[];
+  torrentPeer: string[];
+  torrentTracker: string[];
+  transferSummary: string[];
+};
+
+const EMPTY_METHOD_CALLS: AvailableMethodCalls = {
+  methodList: [],
+  clientSetting: [],
+  torrentContent: [],
+  torrentList: [],
+  torrentPeer: [],
+  torrentTracker: [],
+  transferSummary: [],
+};
+
+async function fetchAvailableMethodCalls(
+  clientRequestManager: ClientRequestManager,
+  fallback = false,
+): Promise<AvailableMethodCalls> {
+  let methodList: Array<string> = [];
+
+  clientRequestManager.isJSONCapable = true;
+  methodList = await clientRequestManager.methodCall('system.listMethods', []).catch((e: RPCError) => {
+    if (e.isRPCError || e.name == 'SyntaxError') {
+      clientRequestManager.isJSONCapable = false;
+    } else if (!fallback) {
+      throw e;
+    }
+  });
+
+  if (!clientRequestManager.isJSONCapable) {
+    methodList = await clientRequestManager.methodCall('system.listMethods', []).catch((e) => {
+      if (!fallback) {
+        throw e;
+      }
+    });
+  }
+
+  const getAvailableMethodCalls =
+    methodList?.length > 0
+      ? (methodCalls: Array<string>) => {
+          return methodCalls.map((method) => (methodList.includes(method.split('=')[0]) ? method : 'false='));
+        }
+      : (methodCalls: Array<string>) => methodCalls;
+
+  return {
+    methodList,
+    clientSetting: getAvailableMethodCalls(getMethodCalls(clientSettingMethodCallConfigs)),
+    torrentContent: getAvailableMethodCalls(getMethodCalls(torrentContentMethodCallConfigs)),
+    torrentList: getAvailableMethodCalls(getMethodCalls(torrentListMethodCallConfigs)),
+    torrentPeer: getAvailableMethodCalls(getMethodCalls(torrentPeerMethodCallConfigs)),
+    torrentTracker: getAvailableMethodCalls(getMethodCalls(torrentTrackerMethodCallConfigs)),
+    transferSummary: getAvailableMethodCalls(getMethodCalls(transferSummaryMethodCallConfigs)),
+  };
+}
+
+class RTorrentClientGatewayService extends BaseClientGatewayService implements ClientGatewayService {
+  clientRequestManager: ClientRequestManager;
+  availableMethodCalls: AvailableMethodCalls;
+
+  constructor(user: UserInDatabase, availableMethodCalls: AvailableMethodCalls) {
+    super(user);
+    this.clientRequestManager = new ClientRequestManager(user.client as RTorrentConnectionSettings);
+    this.availableMethodCalls = availableMethodCalls;
+  }
+
+  static async create(user: UserInDatabase): Promise<RTorrentClientGatewayService> {
+    const clientRequestManager = new ClientRequestManager(user.client as RTorrentConnectionSettings);
+    let availableMethodCalls = await fetchAvailableMethodCalls(clientRequestManager).catch(() => null);
+    if (availableMethodCalls == null) {
+      availableMethodCalls = EMPTY_METHOD_CALLS;
+    }
+    return new RTorrentClientGatewayService(user, availableMethodCalls);
+  }
 
   // workaround: rTorrent instances might reject large d.multicall2 JSON-RPC requests
   // even though the equivalent XML-RPC call succeeds. rakshasa/rtorrent#1596
   private async fetchTorrentListResponses() {
-    const methodCalls = ['', 'main'].concat((await this.availableMethodCalls).torrentList);
+    const methodCalls = ['', 'main'].concat(this.availableMethodCalls.torrentList);
 
     try {
       return await this.clientRequestManager
@@ -81,7 +158,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async getPreferredMethod(methods: string[]): Promise<string> {
-    const {methodList} = await this.availableMethodCalls;
+    const {methodList} = this.availableMethodCalls;
 
     const matchedMethod = methods.find((method) => methodList.includes(method));
 
@@ -261,7 +338,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
 
   async getTorrentContents(hash: TorrentProperties['hash']): Promise<Array<TorrentContent>> {
     return this.clientRequestManager
-      .methodCall('f.multicall', [hash, ''].concat((await this.availableMethodCalls).torrentContent))
+      .methodCall('f.multicall', [hash, ''].concat(this.availableMethodCalls.torrentContent))
       .then(this.processClientRequestSuccess, this.processRTorrentRequestError)
       .then((responses: string[][]) => {
         return Promise.all(
@@ -319,7 +396,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
 
   async getTorrentPeers(hash: TorrentProperties['hash']): Promise<Array<TorrentPeer>> {
     return this.clientRequestManager
-      .methodCall('p.multicall', [hash, ''].concat((await this.availableMethodCalls).torrentPeer))
+      .methodCall('p.multicall', [hash, ''].concat(this.availableMethodCalls.torrentPeer))
       .then(this.processClientRequestSuccess, this.processRTorrentRequestError)
       .then((responses: string[][]) => {
         return Promise.all(
@@ -340,7 +417,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
 
   async getTorrentTrackers(hash: TorrentProperties['hash']): Promise<Array<TorrentTracker>> {
     return this.clientRequestManager
-      .methodCall('t.multicall', [hash, ''].concat((await this.availableMethodCalls).torrentTracker))
+      .methodCall('t.multicall', [hash, ''].concat(this.availableMethodCalls.torrentTracker))
       .then(this.processClientRequestSuccess, this.processRTorrentRequestError)
       .then((responses: string[][]) => {
         return Promise.all(
@@ -578,7 +655,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async setTorrentsSequential({hashes, isSequential}: SetTorrentsSequentialOptions): Promise<void> {
-    const {methodList} = await this.availableMethodCalls;
+    const {methodList} = this.availableMethodCalls;
 
     if (!methodList.includes('d.down.sequential.set')) {
       throw new Error('d.down.sequential.set is not supported by this rTorrent instance');
@@ -801,7 +878,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async fetchTransferSummary(): Promise<TransferSummary> {
-    const methodCalls: MultiMethodCalls = (await this.availableMethodCalls).transferSummary.map((methodCall) => {
+    const methodCalls: MultiMethodCalls = this.availableMethodCalls.transferSummary.map((methodCall) => {
       return {
         methodName: methodCall,
         params: [''],
@@ -824,7 +901,7 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async getClientSettings(): Promise<ClientSettings> {
-    const methodCalls: MultiMethodCalls = (await this.availableMethodCalls).clientSetting.map((methodCall) => {
+    const methodCalls: MultiMethodCalls = this.availableMethodCalls.clientSetting.map((methodCall) => {
       return {
         methodName: methodCall,
         params: [''],
@@ -902,54 +979,9 @@ class RTorrentClientGatewayService extends ClientGatewayService {
   }
 
   async testGateway(): Promise<void> {
-    const availableMethodCalls = await this.fetchAvailableMethodCalls();
-    this.availableMethodCalls = Promise.resolve(availableMethodCalls);
-  }
-
-  async fetchAvailableMethodCalls(fallback = false): Promise<{
-    methodList: string[];
-    clientSetting: string[];
-    torrentContent: string[];
-    torrentList: string[];
-    torrentPeer: string[];
-    torrentTracker: string[];
-    transferSummary: string[];
-  }> {
-    let methodList: Array<string> = [];
-    const listMethods = () => {
-      return this.clientRequestManager
-        .methodCall('system.listMethods', [])
-        .then(this.processClientRequestSuccess, this.processRTorrentRequestError);
-    };
-
-    this.clientRequestManager.isJSONCapable = true;
-    methodList = await listMethods().catch((e: RPCError) => {
-      if (e.isRPCError || e.name == 'SyntaxError') {
-        this.clientRequestManager.isJSONCapable = false;
-      } else if (!fallback) {
-        throw e;
-      }
-    });
-
-    if (!this.clientRequestManager.isJSONCapable) {
-      methodList = await listMethods().catch((e) => {
-        if (!fallback) {
-          throw e;
-        }
-      });
-    }
-
-    const clientSettingCalls = getMethodCalls(clientSettingMethodCallConfigs, methodList);
-
-    return {
-      methodList,
-      clientSetting: clientSettingCalls,
-      torrentContent: getMethodCalls(torrentContentMethodCallConfigs, methodList),
-      torrentList: getMethodCalls(torrentListMethodCallConfigs, methodList),
-      torrentPeer: getMethodCalls(torrentPeerMethodCallConfigs, methodList),
-      torrentTracker: getMethodCalls(torrentTrackerMethodCallConfigs, methodList),
-      transferSummary: getMethodCalls(transferSummaryMethodCallConfigs, methodList),
-    };
+    this.availableMethodCalls = this.processClientRequestSuccess(
+      await fetchAvailableMethodCalls(this.clientRequestManager).catch(this.processRTorrentRequestError),
+    );
   }
 
   processRTorrentRequestError = (error: RPCError) => {


### PR DESCRIPTION
## Summary

- Replaces the `ClientGatewayService` abstract class with an interface and a shared `BaseClientGatewayService` abstract class
- Each implementation receives dependencies (`ClientRequestManager`, `AvailableMethodCalls`) via constructor arguments, eliminating async field initializers
- Each implementation provides a `static async create(user)` factory for construction
- rTorrent's `fetchAvailableMethodCalls` is extracted to a standalone function taking `ClientRequestManager` as an argument — no more `availableMethodCalls = this.fetchAvailableMethodCalls()` pattern
- `testGateway()` is now reserved solely for connectivity re-validation during retries, no longer serving as an async factory/initializer