### PR TITLE
fix: filter qBittorrent trackers by tier>=0 for message extraction

### DIFF
--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -368,17 +368,14 @@ class QBittorrentClientGatewayService extends ClientGatewayService {
             const trackers = await this.clientRequestManager.getTorrentTrackers(hash).catch(() => undefined);
 
             if (properties != null && trackers != null && Array.isArray(trackers)) {
-              const firstTrackerMsg = trackers.find((t) => t.msg.length > 0)?.msg ?? '';
+              const realTrackers = trackers.filter((t) => t.tier >= 0);
+              const firstTrackerMsg = realTrackers.find((t) => t.msg.length > 0)?.msg ?? '';
               this.cachedProperties[hash] = {
                 comment: properties?.comment,
                 dateCreated: properties?.creation_date,
                 isPrivate: trackers[0]?.msg.includes('is private'),
                 trackerMessage: firstTrackerMsg,
-                trackerURIs: getDomainsFromURLs(
-                  trackers
-                    .map((tracker) => tracker.url)
-                    .filter((url) => getTorrentTrackerTypeFromURL(url) !== TorrentTrackerType.DHT),
-                ),
+                trackerURIs: getDomainsFromURLs(realTrackers.map((tracker) => tracker.url)),
               };
             }
           }


### PR DESCRIPTION
## Summary

- Filter qBittorrent trackers by `tier >= 0` when extracting tracker messages and building tracker URIs
- DHT/PeX/LSD trackers (tier < 0) send informational messages like "This torrent is private" that were incorrectly triggering the warning status introduced in #1108
- `isPrivate` detection still uses the raw tracker list (index 0) since DHT trackers may carry the "is private" message

Fixes #1118