### PR TITLE
fix(qBittorrent): session cookie name

### DIFF
--- a/server/services/qBittorrent/clientRequestManager.ts
+++ b/server/services/qBittorrent/clientRequestManager.ts
@@ -73,7 +73,7 @@ class ClientRequestManager {
         const cookies = res.headers['set-cookie'];
 
         if (Array.isArray(cookies)) {
-          return cookies.filter((cookie) => cookie.includes('SID='))[0];
+          return cookies.filter((cookie) => cookie.includes('SID=') || cookie.includes('QBT_SID_'))[0];
         }
 
         return undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After updating to qBittorrent 5.2, Flood is failing to connect with the error below, I found that the session cookie name had been changed from `SID` to `QBT_SID_<WEB_UI_PORT>` (For example `QBT_SID_8080`) https://github.com/qbittorrent/qBittorrent/commit/753fb80e9bf4aa96dbb929f16d29c0156069a2c9
```
{
    "code": "INTERNAL_SERVER_ERROR",
    "message": "AxiosError: Request failed with status code 403"
}
```

## Related Issue
- https://github.com/jesec/flood/issues/1117

## Screenshots

<!--- Optional -->

## Types of changes
I added a check for `QBT_SID_`  along side the check for `SID=` to support qBittorrent 5.2 and maintain backwards compatibility.

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
