### PR TITLE
fix(api): coerce string numbers in client settings PATCH schema

### DIFF
--- a/shared/schema/ClientSettings.ts
+++ b/shared/schema/ClientSettings.ts
@@ -1,30 +1,32 @@
 import type {infer as zodInfer} from 'zod';
-import {array, boolean, number, strictObject, string} from 'zod';
+import {array, boolean, strictObject, string, z} from 'zod';
+
+const coerceNumber = z.coerce.number();
 
 export const clientSettingsSchema = strictObject({
   dht: boolean(),
-  dhtPort: number(),
+  dhtPort: coerceNumber,
   directoryDefault: string(),
-  networkHttpMaxOpen: number(),
+  networkHttpMaxOpen: coerceNumber,
   networkLocalAddress: array(string()),
-  networkMaxOpenFiles: number(),
+  networkMaxOpenFiles: coerceNumber,
   networkPortOpen: boolean(),
   networkPortRandom: boolean(),
   networkPortRange: string(),
   piecesHashOnCompletion: boolean(),
-  piecesMemoryMax: number(),
+  piecesMemoryMax: coerceNumber,
   protocolPex: boolean(),
-  throttleGlobalDownSpeed: number(),
-  throttleGlobalUpSpeed: number(),
-  throttleMaxPeersNormal: number(),
-  throttleMaxPeersSeed: number(),
-  throttleMaxDownloads: number(),
-  throttleMaxDownloadsGlobal: number(),
-  throttleMaxUploads: number(),
-  throttleMaxUploadsGlobal: number(),
-  throttleMinPeersNormal: number(),
-  throttleMinPeersSeed: number(),
-  trackersNumWant: number(),
+  throttleGlobalDownSpeed: coerceNumber,
+  throttleGlobalUpSpeed: coerceNumber,
+  throttleMaxPeersNormal: coerceNumber,
+  throttleMaxPeersSeed: coerceNumber,
+  throttleMaxDownloads: coerceNumber,
+  throttleMaxDownloadsGlobal: coerceNumber,
+  throttleMaxUploads: coerceNumber,
+  throttleMaxUploadsGlobal: coerceNumber,
+  throttleMinPeersNormal: coerceNumber,
+  throttleMinPeersSeed: coerceNumber,
+  trackersNumWant: coerceNumber,
 }).strip();
 
 // PATCH /api/client/settings


### PR DESCRIPTION
## Summary
- Replaced `z.number()` with `z.coerce.number()` for all numeric fields in `clientSettingsSchema`, used by the PATCH `/api/client/settings` endpoint
- This allows the API to accept string representations of numbers (e.g., `"2048"` instead of `2048`) which is what HTML form inputs naturally produce

## Problem
The Settings modal uses `<Textbox>` (HTML input type="text") for numeric fields like `piecesMemoryMax`, which sends values as strings. Previously the Zod schema rejected these, causing `FST_ERR_VALIDATION` errors.

## Fix
Use `z.coerce.number()` which follows the existing pattern used in `shared/schema/api/index.ts` (for `limit`, `start`, `allNotifications`).
