### PR TITLE
chore(Dockerfile): set source to the GH repository

### DIFF
--- a/distribution/containers/Dockerfile.distroless
+++ b/distribution/containers/Dockerfile.distroless
@@ -28,6 +28,7 @@ RUN chown 1001:1001 /root/sysroot/home/download
 
 # flood image
 FROM scratch AS flood
+LABEL org.opencontainers.image.source="https://github.com/jesec/flood"
 
 COPY --from=build /root/sysroot /
 

--- a/distribution/containers/Dockerfile.release
+++ b/distribution/containers/Dockerfile.release
@@ -1,5 +1,6 @@
 # Use node alpine docker image
 FROM docker.io/node:22-alpine
+LABEL org.opencontainers.image.source="https://github.com/jesec/flood"
 
 ARG PACKAGE_TARBALL=artifacts/flood.tgz
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This should allow tools (e.g. Renovate in my case) to find their way back to where the image originates from.

I'm expecting Renovate to crawl back to the repository and fetch the changelog for me this way.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
