### PR TITLE
build: migrate to pnpm 11

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,8 +29,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Install pnpm 9.7.0
-RUN npm install -g pnpm@9.7.0
+# Install pnpm 11.5.2
+RUN npm install -g pnpm@11.5.2
 
 # Install rTorrent from jesec's releases (same as CI)
 RUN wget -q https://github.com/jesec/rtorrent/releases/latest/download/rtorrent-linux-amd64.deb && \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -36,7 +36,7 @@ The dev container image is automatically built and published to GitHub Container
 
 - **OS:** Ubuntu 22.04 LTS (jammy)
 - **Node.js:** v22.x (matches CI and production targets)
-- **Package Manager:** pnpm 9.7.0
+- **Package Manager:** pnpm 11.5.2
 - **Shell:** zsh with Oh My Zsh
 
 ### Development Tools

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -83,7 +83,7 @@ jobs:
           sudo chmod +x /usr/local/bin/ldid
 
       - name: Install pkg
-        run: pnpm add -g @yao-pkg/pkg
+        run: pnpm add -g --config.global-bin-dir="$PNPM_HOME" @yao-pkg/pkg
 
       - name: Build executables
         working-directory: package

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install --reinstall -y qemu-user-static
 
-      - run: pnpm add -g @yao-pkg/pkg
+      - run: pnpm add -g --config.global-bin-dir="$PNPM_HOME" @yao-pkg/pkg
 
       - name: Install Bazel
         run: |

--- a/.github/workflows/publish-rolling.yml
+++ b/.github/workflows/publish-rolling.yml
@@ -46,8 +46,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Exchange OIDC token for npm publish token
         id: npm_token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Exchange OIDC token for npm publish token
         id: npm_token

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-node-linker=hoisted
-hoist-pattern[]=!@lingui/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ pnpm run test                        # Run tests to catch regressions
 ### Build & Run
 
 ```bash
-# Package Manager: pnpm (v9.7.0) is the project's package manager
+# Package Manager: pnpm (v11.5.2) is the project's package manager
 pnpm install --frozen-lockfile  # Install dependencies with lockfile
 pnpm run build                   # Build production (esbuild for server, Vite for client)
 pnpm start                       # Start production server (node --enable-source-maps dist/index.js)

--- a/package.json
+++ b/package.json
@@ -217,5 +217,5 @@
   "lint-staged": {
     "*": "prettier --ignore-unknown -w"
   },
-  "packageManager": "pnpm@9.7.0"
+  "packageManager": "pnpm@11.5.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+nodeLinker: hoisted
+hoistPattern:
+  - '!@lingui/*'
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  esbuild: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrate to pnpm 11 since pnpm 9 is deprecated: https://endoflife.date/pnpm.

## Related Issue

nixpkgs will soon remove pnpn 9 support: https://github.com/NixOS/nixpkgs/issues/529285.

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
