### PR TITLE
feat: add native moving status for torrents

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -35,7 +35,9 @@ jobs:
           mv /tmp/x86_64-qbittorrent-nox /usr/local/bin/qbittorrent-nox
           chmod +x /usr/local/bin/qbittorrent-nox
 
-      - run: sudo apt-get install -y transmission-daemon
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y transmission-daemon
 
       - run: |
           wget https://github.com/jesec/rtorrent/releases/latest/download/rtorrent-linux-amd64.deb

--- a/client/src/javascript/components/general/TorrentStatusIcon.tsx
+++ b/client/src/javascript/components/general/TorrentStatusIcon.tsx
@@ -16,6 +16,8 @@ const TorrentStatusIcon: FC<TorrentStatusIconProps> = memo(({status}: TorrentSta
       return <Error />;
     case 'checking':
       return <Spinner />;
+    case 'moving':
+      return <Spinner />;
     case 'downloading':
       return <Start />;
     case 'seeding':

--- a/client/src/javascript/components/sidebar/SidebarFilter.tsx
+++ b/client/src/javascript/components/sidebar/SidebarFilter.tsx
@@ -74,7 +74,7 @@ const SidebarFilter: FC<SidebarFilterProps> = ({
     name = i18n._('filter.untagged');
   }
 
-  if (slug === 'checking' || slug === 'error') {
+  if (slug === 'checking' || slug === 'moving' || slug === 'error') {
     if (count === 0) {
       return null;
     }

--- a/client/src/javascript/components/sidebar/StatusFilters.tsx
+++ b/client/src/javascript/components/sidebar/StatusFilters.tsx
@@ -50,6 +50,11 @@ const StatusFilters: FC = observer(() => {
       icon: <Spinner />,
     },
     {
+      label: i18n._('filter.status.moving'),
+      slug: 'moving',
+      icon: <Spinner />,
+    },
+    {
       label: i18n._('filter.status.completed'),
       slug: 'complete',
       icon: <Completed />,

--- a/client/src/javascript/i18n/strings/en.json
+++ b/client/src/javascript/i18n/strings/en.json
@@ -136,6 +136,7 @@
   "filter.status.downloading": "Downloading",
   "filter.status.error": "Error",
   "filter.status.inactive": "Inactive",
+  "filter.status.moving": "Moving",
   "filter.status.warning": "Warning",
   "filter.status.seeding": "Seeding",
   "filter.status.stopped": "Stopped",

--- a/client/src/javascript/util/torrentStatus.ts
+++ b/client/src/javascript/util/torrentStatus.ts
@@ -16,13 +16,14 @@ export const torrentStatusClasses = (
     'torrent--is-seeding': status.includes('seeding'),
     'torrent--is-completed': status.includes('complete'),
     'torrent--is-checking': status.includes('checking'),
+    'torrent--is-moving': status.includes('moving'),
     'torrent--is-inactive': status.includes('inactive'),
   });
 
 export const torrentStatusEffective = (status: TorrentProperties['status']): TorrentProperties['status'][number] => {
   let result: TorrentProperties['status'][number] = 'stopped';
 
-  ['warning', 'error', 'checking', 'stopped', 'downloading', 'seeding'].some((state) => {
+  ['warning', 'error', 'moving', 'checking', 'stopped', 'downloading', 'seeding'].some((state) => {
     if (status.includes(state as TorrentProperties['status'][number])) {
       result = state as TorrentProperties['status'][number];
       return true;

--- a/server/services/qBittorrent/util/torrentPropertiesUtil.ts
+++ b/server/services/qBittorrent/util/torrentPropertiesUtil.ts
@@ -86,6 +86,8 @@ export const getTorrentStatusFromState = (
       statuses.push('checking');
       break;
     case 'moving':
+      statuses.push('moving');
+      break;
     case 'checkingResumeData':
     case 'unknown':
       statuses.push('checking');

--- a/shared/constants/torrentStatusMap.ts
+++ b/shared/constants/torrentStatusMap.ts
@@ -8,6 +8,7 @@ const torrentStatusMap = [
   'inactive',
   'warning',
   'error',
+  'moving',
 ] as const;
 
 export type TorrentStatus = (typeof torrentStatusMap)[number];


### PR DESCRIPTION
## Summary

- Add `'moving'` as a distinct torrent status in `torrentStatusMap`
- Map qBittorrent `'moving'` state to the new `'moving'` status (previously shown as `'checking'`)
- Add sidebar filter for moving torrents (hidden when count is 0)
- Add CSS class `torrent--is-moving` and effective status priority support

## Motivation

qBittorrent has a native `'moving'` state for torrents whose data is being relocated. Previously this was mapped to `'checking'`, which is misleading. This PR separates it into its own status so users can clearly distinguish between hash checking and data moving.