### PR TITLE
fix(neptune): determine isActive by actual transfer rates instead of state

### DIFF
--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -267,7 +267,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
           );
 
           const isComplete = torrent.state === 'Seeding';
-          const isActive = torrent.state === 'Downloading' || torrent.state === 'Seeding';
+          const isActive = torrent.upload_rate > 0 && torrent.download_rate > 0;
 
           const trackerErrorMessages = Object.values(torrent.tracker_errors ?? {}).filter(Boolean);
           const trackerMessage = trackerErrorMessages.find((m) => m.length > 0) ?? '';


### PR DESCRIPTION
## Summary

- Fix `isActive` logic in Neptune client: a torrent is now considered active only when it has both upload and download transfer rates > 0, instead of checking the torrent state.