### PR TITLE
build(distroless): use uutils/coreutils for df binary

### DIFF
--- a/distribution/containers/Dockerfile.distroless
+++ b/distribution/containers/Dockerfile.distroless
@@ -14,8 +14,17 @@ RUN if [[ `uname -m` == "aarch64" ]]; \
 RUN mv flood /root/sysroot/bin/flood
 
 
-RUN apk --no-cache add tini-static coreutils
-RUN cp /bin/df /root/sysroot/bin/df
+ARG COREUTILS_VERSION=0.9.0
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then COREUTILS_ARCH="aarch64"; else COREUTILS_ARCH="x86_64"; fi \
+    && wget -qO /tmp/coreutils.tar.gz \
+       "https://github.com/uutils/coreutils/releases/download/${COREUTILS_VERSION}/coreutils-${COREUTILS_VERSION}-${COREUTILS_ARCH}-unknown-linux-musl.tar.gz" \
+    && tar xzf /tmp/coreutils.tar.gz -C /tmp \
+    && mv /tmp/coreutils-${COREUTILS_VERSION}-${COREUTILS_ARCH}-unknown-linux-musl/coreutils /root/sysroot/bin/coreutils \
+    && ln -s coreutils /root/sysroot/bin/df \
+    && rm -rf /tmp/coreutils.tar.gz /tmp/coreutils-*
+
+RUN apk --no-cache add tini-static
 RUN cp /sbin/tini-static /root/sysroot/bin/tini
 
 RUN chmod 0555 /root/sysroot/bin/*


### PR DESCRIPTION
## Summary

- Replace Alpine's `coreutils` package in the distroless Dockerfile with the `df` binary from [uutils/coreutils](https://github.com/uutils/coreutils) v0.9.0 release
- Uses the musl-linked multi-call binary with a symlink so `df` dispatches correctly via `argv[0]`
- Supports both x86_64 and aarch64 architectures via `TARGETARCH`