### PR TITLE
feat: register as OS handler for .torrent files and magnet links

### DIFF
--- a/client/src/javascript/components/general/form-elements/FileDropzone.tsx
+++ b/client/src/javascript/components/general/form-elements/FileDropzone.tsx
@@ -4,8 +4,9 @@ import {Trans} from '@lingui/react';
 
 import {Close, File, Files} from '@client/ui/icons';
 import {FormRowItem} from '@client/ui';
+import processFiles from '@client/util/processFiles';
 
-export type ProcessedFiles = Array<{name: string; data: string}>;
+import type {ProcessedFiles} from '@client/util/processFiles';
 
 interface FileDropzoneProps {
   initialFiles?: ProcessedFiles;
@@ -56,21 +57,8 @@ const FileDropzone: FC<FileDropzoneProps> = ({initialFiles, onFilesChanged}: Fil
       ) : null}
       <Dropzone
         onDrop={(addedFiles: Array<File>) => {
-          const processedFiles: ProcessedFiles = [];
-          addedFiles.forEach((file) => {
-            const reader = new FileReader();
-            reader.onload = (e) => {
-              if (e.target?.result != null && typeof e.target.result === 'string') {
-                processedFiles.push({
-                  name: file.name,
-                  data: e.target.result.split('base64,')[1],
-                });
-              }
-              if (processedFiles.length === addedFiles.length) {
-                setFiles(files.concat(processedFiles));
-              }
-            };
-            reader.readAsDataURL(file);
+          void processFiles(addedFiles).then((processedFiles) => {
+            setFiles(files.concat(processedFiles));
           });
         }}
       >

--- a/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByFile.tsx
+++ b/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByFile.tsx
@@ -12,7 +12,7 @@ import FileDropzone from '../../general/form-elements/FileDropzone';
 import FilesystemBrowserTextbox from '../../general/form-elements/FilesystemBrowserTextbox';
 import TagSelect from '../../general/form-elements/TagSelect';
 
-import type {ProcessedFiles} from '../../general/form-elements/FileDropzone';
+import type {ProcessedFiles} from '@client/util/processFiles';
 
 interface AddTorrentsByFileFormData {
   destination: string;

--- a/client/src/javascript/components/torrent-list/TorrentListDropzone.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListDropzone.tsx
@@ -1,28 +1,14 @@
-import {FC, ReactNode} from 'react';
+import {FC, ReactNode, useEffect} from 'react';
 import {useDropzone} from 'react-dropzone';
 
 import UIStore from '@client/stores/UIStore';
-
-import type {ProcessedFiles} from '@client/components/general/form-elements/FileDropzone';
+import processFiles from '@client/util/processFiles';
 
 const handleFileDrop = (files: Array<File>) => {
-  const processedFiles: ProcessedFiles = [];
-
-  files.forEach((file) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      if (e.target?.result != null && typeof e.target.result === 'string') {
-        processedFiles.push({
-          name: file.name,
-          data: e.target.result.split('base64,')[1],
-        });
-      }
-
-      if (processedFiles.length === files.length && processedFiles[0] != null) {
-        UIStore.setActiveModal({id: 'add-torrents', tab: 'by-file', files: processedFiles});
-      }
-    };
-    reader.readAsDataURL(file);
+  void processFiles(files).then((processedFiles) => {
+    if (processedFiles.length > 0) {
+      UIStore.setActiveModal({id: 'add-torrents', tab: 'by-file', files: processedFiles});
+    }
   });
 };
 
@@ -32,6 +18,17 @@ const TorrentListDropzone: FC<{children: ReactNode}> = ({children}: {children: R
     noClick: true,
     noKeyboard: true,
   });
+
+  // When opened as the OS handler for a .torrent file, launchQueue buffers the launch until
+  // a consumer registers, so a cold launch onto the login screen is still delivered once this
+  // mounts post-auth.
+  useEffect(() => {
+    window.launchQueue?.setConsumer(({files}) => {
+      if (files != null && files.length > 0) {
+        void Promise.all(files.map((handle) => handle.getFile())).then(handleFileDrop);
+      }
+    });
+  }, []);
 
   return (
     <div

--- a/client/src/javascript/stores/UIStore.ts
+++ b/client/src/javascript/stores/UIStore.ts
@@ -1,7 +1,7 @@
 import {makeAutoObservable} from 'mobx';
 import React, {FC, MouseEvent} from 'react';
 
-import type {ProcessedFiles} from '@client/components/general/form-elements/FileDropzone';
+import type {ProcessedFiles} from '@client/util/processFiles';
 import type {TorrentContextMenuAction} from '@client/constants/TorrentContextMenuActions';
 
 export type ContextMenuItem =

--- a/client/src/javascript/typings.d.ts
+++ b/client/src/javascript/typings.d.ts
@@ -6,3 +6,17 @@ declare module '*.md' {
 declare module '*?lingui' {
   export const messages: Record<string, string[]>;
 }
+
+// File Handling API (launchQueue) — not yet in TypeScript's DOM lib.
+// FileSystemFileHandle already is.
+interface LaunchParams {
+  readonly files?: ReadonlyArray<FileSystemFileHandle>;
+}
+
+interface LaunchQueue {
+  setConsumer: (consumer: (params: LaunchParams) => void) => void;
+}
+
+interface Window {
+  readonly launchQueue?: LaunchQueue;
+}

--- a/client/src/javascript/util/processFiles.ts
+++ b/client/src/javascript/util/processFiles.ts
@@ -1,0 +1,20 @@
+export type ProcessedFiles = Array<{name: string; data: string}>;
+
+const readFile = (file: File): Promise<ProcessedFiles[number]> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      if (typeof e.target?.result === 'string') {
+        resolve({name: file.name, data: e.target.result.split('base64,')[1]});
+      } else {
+        reject(new Error(`Unable to read file: ${file.name}`));
+      }
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+
+// Reads each file into the base64 payload the add-torrent API expects.
+const processFiles = (files: Array<File>): Promise<ProcessedFiles> => Promise.all(files.map(readFile));
+
+export default processFiles;

--- a/client/src/public/manifest.json
+++ b/client/src/public/manifest.json
@@ -43,5 +43,19 @@
   "start_url": "./index.html",
   "description": "Web UI for torrent clients",
   "background_color": "#ffffff",
-  "theme_color": "#349cf4"
+  "theme_color": "#349cf4",
+  "protocol_handlers": [
+    {
+      "protocol": "magnet",
+      "url": "./index.html?action=add-urls&url=%s"
+    }
+  ],
+  "file_handlers": [
+    {
+      "action": "./index.html",
+      "accept": {
+        "application/x-bittorrent": [".torrent"]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This makes Flood show up as an application to open torrent files with in OS native file type properties (when you install as PWA). With this, I can completely replace the Transmission desktop app with Flood :grin:.

## Description


Magnet links already worked via the in-app registerProtocolHandler button and the existing `?action=add-urls` query branch in AppWrapper; the manifest protocol_handlers entry just makes that registration happen automatically on install, reusing the same handler URL.

For .torrent files, I registered a `launchQueue` consumer (File Handling API) in TorrentListDropzone. The logic was the exact same as the drag-and-drop torrent-file intake, so I thought this was a good place - let me know if you want it somewhere else. `launchQueue` buffers the launch until the consumer mounts, so a cold launch still gets delivered after login.

While I was there, I noticed the base64 file processing was duplicated between `TorrentListDropzone` and `FileDropzone`. So I extracted it to `util/processFiles`.

I've tested and it works great on Chromium, but both handlers are feature-detected and should do nothing where the APIs are unavailable (Firefox, Safari/iOS).

## Screenshots

<img width="608" height="735" alt="image" src="https://github.com/user-attachments/assets/c9074122-6cc5-4e9a-9909-c9eaa9bf2f78" />


## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [x] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
