### PR TITLE
perf(neptune): remove N+1 getTorrentTrackers calls in fetchTorrentList

### DIFF
--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -260,11 +260,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
         const torrentList: TorrentList = {};
 
         for (const torrent of response.torrents) {
-          const trackerURIs = getDomainsFromURLs(
-            (
-              await this.clientRequestManager.getTorrentTrackers(torrent.hash).catch(() => ({trackers: []}))
-            ).trackers.map((t) => t.url),
-          );
+          const trackerURIs = getDomainsFromURLs(Object.keys(torrent.tracker_errors ?? {}));
 
           const isComplete = torrent.state === 'Seeding';
 


### PR DESCRIPTION
## Problem

`fetchTorrentList()` issues `torrent.trackers` for **every** torrent in the list every poll cycle (default: 2s). With N torrents this produces `1 + N` HTTP requests **serially** via `for...of` + `await`.

CPU profiling shows `getTorrentTrackers` and related HTTP I/O consume **~40% of non-idle CPU time**.

## Fix

Use `Object.keys(torrent.tracker_errors)` which is already returned in the `torrent.list` response — the keys are tracker URLs. No additional RPC call needed.

## Before / After

```
Before:  1 x torrent.list  +  N x torrent.trackers  (serial, per poll)
After:   1 x torrent.list                            (no extra calls)
```

## Verification

- [x] `pnpm run check-types` passes
- [x] `pnpm run lint` passes