### PR TITLE
fix(neptune): map peers/seeds count from torrent list API

### DIFF
--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -286,15 +286,15 @@ class NeptuneClientGatewayService extends ClientGatewayService {
             message: combinedMessage,
             name: torrent.name,
             peersConnected: torrent.connection_count,
-            peersTotal: 0,
+            peersTotal: torrent.total_downloading,
             percentComplete: torrent.total_length > 0 ? (torrent.completed / torrent.selected_size) * 100 : 0,
             priority: 1,
             ratio:
               torrent.upload_total > 0 && torrent.download_total > 0
                 ? torrent.upload_total / torrent.download_total
                 : 0,
-            seedsConnected: 0,
-            seedsTotal: 0,
+            seedsConnected: torrent.connected_seeding,
+            seedsTotal: torrent.total_seeding,
             sizeBytes: torrent.total_length,
             status: getTorrentStatusFromState(
               torrent.state as NeptuneTorrentState,

--- a/server/services/Neptune/neptune-client.ts
+++ b/server/services/Neptune/neptune-client.ts
@@ -93,6 +93,10 @@ export interface NeptuneTorrent {
   selected_size: number;
   add_at: number;
   private: boolean;
+  total_seeding: number;
+  total_downloading: number;
+  connected_seeding: number;
+  connected_downloading: number;
 }
 
 export interface NeptuneTorrentList {


### PR DESCRIPTION
Neptune's `torrent.list` API already returns `total_seeding`, `total_downloading`, `connected_seeding`, and `connected_downloading` in `MainDataTorrent`, but Flood wasn't using them, causing peers/seeds count to always show 0 in the frontend.

## Changes

- **`neptune-client.ts`**: Added 4 missing fields to `NeptuneTorrent` type
- **`clientGatewayService.ts`**: Map the fields to `TorrentProperties`

Mapping:
| Field | Before | After |
|-------|--------|-------|
| peersTotal | 0 | torrent.total_downloading |
| seedsConnected | 0 | torrent.connected_seeding |
| seedsTotal | 0 | torrent.total_seeding |