### PR TITLE
chore(ci): upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download package artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs['package-artifact'] }}
           path: artifacts
@@ -62,7 +62,7 @@ jobs:
       - uses: pnpm/action-setup@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs['node-version'] }}
           cache: pnpm
@@ -100,7 +100,7 @@ jobs:
           fi
 
       - name: Upload pkg artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs['upload-name'] }}
           path: |

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -19,11 +19,11 @@ jobs:
         node: ['22']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           registry-url: 'https://registry.npmjs.org'
@@ -64,7 +64,7 @@ jobs:
           cp -L bazel-bin/flood-deb-x64.deb flood-linux-x64.deb
 
       - name: Upload Debian artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: flood-debian
           path: |

--- a/.github/workflows/build-docker-distroless.yml
+++ b/.github/workflows/build-docker-distroless.yml
@@ -48,10 +48,10 @@ jobs:
           --name ci-registry
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download pkg binaries artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs['binary-artifact'] }}
           path: artifacts
@@ -62,23 +62,23 @@ jobs:
           printf 'flood=%s\n' "${LOCAL_REGISTRY}/${{ inputs['flood-repository'] }}:${{ inputs['flood-version'] }}-distroless" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: network=host
 
       - name: Login to Docker Hub
         if: inputs.push
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: 'jesec'
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
         if: inputs.push
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build flood distroless image
         id: build_flood
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./distribution/containers/Dockerfile.distroless

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -57,10 +57,10 @@ jobs:
         options: >-
           --name ci-registry
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download package artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs['package-artifact'] }}
           path: artifacts
@@ -75,23 +75,23 @@ jobs:
           printf 'flood=%s\n' "${LOCAL_REGISTRY}/${{ inputs['flood-repository'] }}:${{ inputs['flood-version'] }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: network=host
 
       - name: Login to Docker Hub
         if: inputs.push
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: jesec
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
         if: inputs.push
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Build flood image
         id: build_flood
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./distribution/containers/Dockerfile.release

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,10 +19,10 @@ jobs:
         check: [check-source-formatting, check-types, lint]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/devcontainer-prebuild.yml
+++ b/.github/workflows/devcontainer-prebuild.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/distribute-archlinux.yml
+++ b/.github/workflows/distribute-archlinux.yml
@@ -11,7 +11,7 @@ jobs:
   aur:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Parse version
         id: parse_version
@@ -25,10 +25,10 @@ jobs:
           sed -i 's/version-to-be-replaced/${{ steps.parse_version.outputs.VERSION }}/' ./distribution/archlinux/flood/PKGBUILD
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Publish to AUR
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             AUR_FOLDER=./flood

--- a/.github/workflows/distribute-debian.yml
+++ b/.github/workflows/distribute-debian.yml
@@ -16,14 +16,14 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Parse version
         id: parse_version
         run: echo VERSION=`jq .version package.json -r` >> $GITHUB_OUTPUT
 
       - name: Download Debian artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: flood-debian
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,10 +48,10 @@ jobs:
       tarball: ${{ steps.pack.outputs.tarball }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: pnpm
@@ -99,7 +99,7 @@ jobs:
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
       - name: Upload package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-package
           path: ${{ steps.pack.outputs.tarball }}

--- a/.github/workflows/publish-rolling.yml
+++ b/.github/workflows/publish-rolling.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write
     steps:
       - name: Download package artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: npm-package
           path: artifacts
@@ -40,18 +40,18 @@ jobs:
         run: echo "path=$(ls artifacts/*.tgz)" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: latest
 
       - name: Exchange OIDC token for npm publish token
         id: npm_token
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const idToken = await core.getIDToken('npm:registry.npmjs.org');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Download package artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: npm-package
           path: artifacts
@@ -27,18 +27,18 @@ jobs:
         run: echo "path=$(ls artifacts/*.tgz)" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: latest
 
       - name: Exchange OIDC token for npm publish token
         id: npm_token
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const idToken = await core.getIDToken('npm:registry.npmjs.org');
@@ -96,16 +96,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download pkg artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pkg-binaries
           path: release-assets
 
       - name: Download debian artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: flood-debian
           path: release-assets
@@ -117,7 +117,7 @@ jobs:
           git for-each-ref ${{ github.ref }} --format="%(contents)" > body
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
@@ -48,7 +48,7 @@ jobs:
         env:
           FLOOD_OPTION_ASSETS: 'false'
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v7
         if: matrix.node == '24'
 
   test-backend:

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -18,10 +18,10 @@ jobs:
         node: ['22']
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Crowdin Action
-        uses: crowdin/github-action@1.4.8
+        uses: crowdin/github-action@v2
         with:
           config: 'crowdin.yml'
           localization_branch_name: integration/translations

--- a/.github/workflows/update-mmdb.yaml
+++ b/.github/workflows/update-mmdb.yaml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -47,7 +47,7 @@ jobs:
         run: node scripts/update-mmdb.mjs
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/update-mmdb


### PR DESCRIPTION
Upgrade all GitHub Actions to latest major versions to resolve Node.js 20 deprecation warnings.

| Action | Old | New |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| pnpm/action-setup | v4 | v6 |
| codecov/codecov-action | v3 | v7 |
| docker/build-push-action | v5 | v7 |
| docker/setup-buildx-action | v3 | v4 |
| docker/setup-qemu-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| peter-evans/create-pull-request | v7 | v8 |
| actions/github-script | v7 | v9 |
| softprops/action-gh-release | v2 | v3 |
| crowdin/github-action | 1.4.8 | v2 |