### PR TITLE
fix: replace deprecated `fs.rmdir` with `fs.rm`

### DIFF
--- a/server/models/Users.ts
+++ b/server/models/Users.ts
@@ -127,7 +127,7 @@ class Users {
       await destroyUserServices(_id, true);
 
       await this.db.remove({username}, {});
-      await fs.promises.rmdir(path.join(config.dbPath, _id), {recursive: true}).catch(() => undefined);
+      await fs.promises.rm(path.join(config.dbPath, _id), {recursive: true}).catch(() => undefined);
 
       return _id;
     });


### PR DESCRIPTION
## Summary

Only `fs.rmdir(path, { recursive: true })` is deprecated ([DEP0147](https://nodejs.org/api/deprecations.html#dep0147_fsrmdirpath--recursive-true)). `fs.rmdir(path)` without `recursive` is fine.

The single affected call site in the codebase is `server/models/Users.ts`.

## Changes

- **`server/models/Users.ts`**: `fs.promises.rmdir(path, { recursive: true })` → `fs.promises.rm(path, { recursive: true })`