### PR TITLE
fix(neptune): map peersConnected to connected_downloading instead of connection_count

### DIFF
--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -286,7 +286,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
             isSequential: false,
             message: combinedMessage,
             name: torrent.name,
-            peersConnected: torrent.connection_count,
+            peersConnected: torrent.connected_downloading,
             peersTotal: torrent.total_downloading,
             percentComplete: torrent.total_length > 0 ? (torrent.completed / torrent.selected_size) * 100 : 0,
             priority: 1,


### PR DESCRIPTION
## Problem

`peersConnected` was mapped to Neptune's `connection_count` field, which represents the **total** number of connected peers (seeders + leechers). This caused connected seeders to be incorrectly counted as leecher peers.

## Fix

Map `peersConnected` to `connected_downloading` instead, which (like the field name suggests) only tracks connected leecher peers.

The related seeder field (`seedsConnected`) correctly maps to `connected_seeding` — this was already correct.