### PR TITLE
fix(neptune): distinguish connection errors from RPC business errors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,6 @@ css-snapshots/
 *storybook.log
 storybook-static
 .codex
+
+# Neptune SDK (synced from external repo)
+server/services/Neptune/sdk/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ export default [
       '**/*.d.ts',
       '**/styled-system/**',
       '**/storybook-static/**',
+      'server/services/Neptune/sdk/**',
     ],
   },
 

--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -33,7 +33,7 @@ import {fetchUrls} from '../../util/fetchUtil';
 import {getDomainsFromURLs} from '../../util/torrentPropertiesUtil';
 import ClientGatewayService from '../clientGatewayService';
 import ClientRequestManager from './clientRequestManager';
-import {NeptuneConnectionError, NeptuneHTTPError, NeptuneRPCError} from './sdk/errors.ts';
+import {NeptuneConnectionError, NeptuneHTTPError} from './sdk/errors.ts';
 import type {TorrentState} from './sdk/types.ts';
 import {getTorrentStatusFromState, getTorrentTrackerTypeFromURL} from './util/torrentPropertiesUtil';
 

--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -33,11 +33,28 @@ import {fetchUrls} from '../../util/fetchUtil';
 import {getDomainsFromURLs} from '../../util/torrentPropertiesUtil';
 import ClientGatewayService from '../clientGatewayService';
 import ClientRequestManager from './clientRequestManager';
+import {NeptuneConnectionError, NeptuneHTTPError, NeptuneRPCError} from './sdk/errors.ts';
 import type {TorrentState} from './sdk/types.ts';
 import {getTorrentStatusFromState, getTorrentTrackerTypeFromURL} from './util/torrentPropertiesUtil';
 
 class NeptuneClientGatewayService extends ClientGatewayService {
   private clientRequestManager = new ClientRequestManager(this.user.client as NeptuneConnectionSettings);
+
+  processClientRequestError = (error: Error): never => {
+    // Only connection-level errors (network failure or HTTP error) should
+    // trigger connection state changes. RPC errors mean the server responded
+    // correctly but rejected the operation (e.g. "reannounce not allowed yet").
+    if (error instanceof NeptuneConnectionError || error instanceof NeptuneHTTPError) {
+      if (this.errorCount === 0) {
+        this.errorCount += 1;
+        this.emit('CLIENT_CONNECTION_STATE_CHANGE', false);
+      }
+
+      this.startTimer();
+    }
+
+    throw error;
+  };
 
   async addTorrentsByFile({
     files,

--- a/server/services/Neptune/sdk/client.ts
+++ b/server/services/Neptune/sdk/client.ts
@@ -1,9 +1,10 @@
-import {NeptuneHTTPError, NeptuneRPCError} from './errors.ts';
+import {NeptuneConnectionError, NeptuneHTTPError, NeptuneRPCError} from './errors.ts';
 import type {
   AddTorrentParams,
   AddTorrentResult,
   AddTrackerParams,
   DelCustomParams,
+  GetRecheckOnCompleteResult,
   GlobalSpeedLimitParams,
   InfoHashParams,
   ListTorrentParams,
@@ -13,6 +14,7 @@ import type {
   ReplaceTrackersParams,
   SetCustomParams,
   SetFilePriorityParams,
+  SetRecheckOnCompleteParams,
   SpeedLimitParams,
   TagsParams,
   TorrentFiles,
@@ -76,6 +78,8 @@ export interface NeptuneMethodMap {
   'client.set_download_limit': {params: GlobalSpeedLimitParams; result: void};
   'client.set_upload_limit': {params: GlobalSpeedLimitParams; result: void};
   'client.get_transfer_config': {params: Record<string, never>; result: TransferConfig};
+  'client.set_recheck_on_complete': {params: SetRecheckOnCompleteParams; result: void};
+  'client.get_recheck_on_complete': {params: Record<string, never>; result: GetRecheckOnCompleteResult};
 }
 
 /** Union of all method name strings. */
@@ -144,12 +148,12 @@ export class NeptuneClient {
    * @param method  – the method name (e.g. `'torrent.list'`).
    * @param params  – method parameters (optional when the method takes none).
    * @returns The parsed result.
+   * @throws {NeptuneConnectionError} when a low-level connection failure occurs.
+   * @throws {NeptuneHTTPError} when the server returns a non-2xx HTTP status.
    * @throws {NeptuneRPCError} when the server returns a JSON-RPC error.
-   * @throws {NeptuneHTTPError} when the HTTP request fails.
    */
   async call<M extends NeptuneMethod>(
     method: M,
-    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     ...args: {} extends NeptuneMethodMap[M]['params']
       ? [params?: NeptuneMethodMap[M]['params']]
       : [params: NeptuneMethodMap[M]['params']]
@@ -174,7 +178,7 @@ export class NeptuneClient {
         body: JSON.stringify(request),
       });
     } catch (err) {
-      throw new NeptuneHTTPError(`Failed to reach Neptune at ${this.#baseUrl}: ${String(err)}`);
+      throw new NeptuneConnectionError(`Failed to reach Neptune at ${this.#baseUrl}: ${String(err)}`, err);
     }
 
     if (!response.ok) {

--- a/server/services/Neptune/sdk/errors.ts
+++ b/server/services/Neptune/sdk/errors.ts
@@ -25,14 +25,28 @@ export class NeptuneRPCError extends Error {
 }
 
 /**
- * Error thrown when the HTTP request itself fails (network error,
- * non-2xx status, etc.).
+ * Error thrown when a low-level connection failure occurs (DNS resolution,
+ * connection refused, timeout, etc.).
+ */
+export class NeptuneConnectionError extends Error {
+  /** The original error that caused the connection failure, if available. */
+  cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'NeptuneConnectionError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * Error thrown when the server returns a non-2xx HTTP status.
  */
 export class NeptuneHTTPError extends Error {
-  /** HTTP status code, if available. */
-  status?: number;
+  /** HTTP status code returned by the server. */
+  status: number;
 
-  constructor(message: string, status?: number) {
+  constructor(message: string, status: number) {
     super(message);
     this.name = 'NeptuneHTTPError';
     this.status = status;

--- a/server/services/Neptune/sdk/index.ts
+++ b/server/services/Neptune/sdk/index.ts
@@ -1,6 +1,8 @@
-export type {NeptuneClientOptions, NeptuneMethod, NeptuneMethodMap} from './client.ts';
 export {NeptuneClient} from './client.ts';
-export {NeptuneHTTPError, NeptuneRPCError} from './errors.ts';
+export type {NeptuneClientOptions, NeptuneMethod, NeptuneMethodMap} from './client.ts';
+
+export {NeptuneConnectionError, NeptuneHTTPError, NeptuneRPCError} from './errors.ts';
+
 export type {
   AddTorrentParams,
   AddTorrentResult,

--- a/server/services/Neptune/sdk/types.ts
+++ b/server/services/Neptune/sdk/types.ts
@@ -35,6 +35,7 @@ export interface Torrent {
   selected_size: number;
   add_at: number;
   completed_at: number;
+  corrupted: number;
   private: boolean;
   total_seeding: number;
   total_downloading: number;
@@ -66,6 +67,7 @@ export interface Peer {
   download_rate: number;
   upload_rate: number;
   is_incoming: boolean;
+  encrypted: boolean;
 }
 
 /** A tracker entry. */
@@ -195,4 +197,15 @@ export interface UpdateCustomParams extends InfoHashParams {
 
 export interface DelCustomParams extends InfoHashParams {
   key: string;
+}
+
+/** Parameters for client.set_recheck_on_complete. */
+export interface SetRecheckOnCompleteParams {
+  /** Whether to recheck all pieces on download completion. */
+  enabled: boolean;
+}
+
+/** Response for client.get_recheck_on_complete. */
+export interface GetRecheckOnCompleteResult {
+  enabled: boolean;
 }


### PR DESCRIPTION
Neptune SDK now distinguishes three error types:
- **NeptuneConnectionError** — low-level connection failure (DNS, connection refused, timeout)
- **NeptuneHTTPError** — non-2xx HTTP status from the server
- **NeptuneRPCError** — JSON-RPC error (server responded correctly but rejected the operation)

Previously, all errors went through `processClientRequestError` which would increment `errorCount`, emit `CLIENT_CONNECTION_STATE_CHANGE` (disconnected), and start a retry timer. This was incorrect for RPC errors like `"reannounce not allowed yet"` — the server is healthy, it just rejected a specific operation.

This PR overrides `processClientRequestError` in `NeptuneClientGatewayService` to only trigger connection state changes for `NeptuneConnectionError` and `NeptuneHTTPError`. `NeptuneRPCError` is simply re-thrown as a normal API error without affecting connection state.