### PR TITLE
fix: use Math.round instead of Math.floor for percentComplete

### DIFF
--- a/.storybook/mocks/MockStateStore.ts
+++ b/.storybook/mocks/MockStateStore.ts
@@ -447,7 +447,7 @@ class MockStateStore {
     this.setTorrent(hash, {
       ...torrent,
       bytesDone: newBytesDone,
-      percentComplete: Math.floor(progress),
+      percentComplete: Math.round(progress),
       eta: eta,
       downTotal: newDownTotal,
       upTotal: newUpTotal,

--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -127,7 +127,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
           index: file.index,
           path: file.path.join('/'),
           filename: file.path[file.path.length - 1] || '',
-          percentComplete: file.progress * 100,
+          percentComplete: Math.round(file.progress * 10000) / 100,
           priority: TorrentContentPriority.NORMAL,
           sizeBytes: file.size,
         }));
@@ -311,7 +311,8 @@ class NeptuneClientGatewayService extends ClientGatewayService {
             name: torrent.name,
             peersConnected: torrent.connected_downloading,
             peersTotal: torrent.total_downloading,
-            percentComplete: torrent.total_length > 0 ? (torrent.completed / torrent.selected_size) * 100 : 0,
+            percentComplete:
+              torrent.total_length > 0 ? Math.round((torrent.completed / torrent.selected_size) * 10000) / 100 : 0,
             priority: 1,
             ratio:
               torrent.upload_total > 0 && torrent.download_total > 0

--- a/server/services/rTorrent/util/numberUtils.ts
+++ b/server/services/rTorrent/util/numberUtils.ts
@@ -1,6 +1,6 @@
 const truncateTo = (num: number, precision = 0) => {
   const factor = 10 ** precision;
-  return Math.floor(num * factor) / factor;
+  return Math.round(num * factor) / factor;
 };
 
 export default truncateTo;


### PR DESCRIPTION
Replace Math.floor with Math.round for percentComplete calculations across the codebase.

- rTorrent: change truncateTo from Math.floor to Math.round
- Neptune: add Math.round to both file-level and torrent-level percentComplete
- MockStateStore: change Math.floor to Math.round for progress simulation