### PR TITLE
fix: revert Math.round to Math.floor for percentComplete calculations

### DIFF
--- a/.storybook/mocks/MockStateStore.ts
+++ b/.storybook/mocks/MockStateStore.ts
@@ -447,7 +447,7 @@ class MockStateStore {
     this.setTorrent(hash, {
       ...torrent,
       bytesDone: newBytesDone,
-      percentComplete: Math.round(progress),
+      percentComplete: Math.floor(progress),
       eta: eta,
       downTotal: newDownTotal,
       upTotal: newUpTotal,

--- a/.storybook/mocks/_fixtures.ts
+++ b/.storybook/mocks/_fixtures.ts
@@ -143,7 +143,7 @@ export function generateMockTorrent(overrides: Partial<TorrentProperties> = {}):
     message: '',
     peersConnected: 12,
     peersTotal: 50,
-    percentComplete: Math.round(percentComplete * 100) / 100,
+    percentComplete: Math.floor(percentComplete * 100) / 100,
     priority: TorrentPriority.NORMAL,
     ratio: Math.round(ratio * 1000) / 1000,
     seedsConnected: 5,

--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -126,7 +126,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
           index: file.index,
           path: file.path.join('/'),
           filename: file.path[file.path.length - 1] || '',
-          percentComplete: Math.round(file.progress * 10000) / 100,
+          percentComplete: Math.floor(file.progress * 10000) / 100,
           priority: TorrentContentPriority.NORMAL,
           sizeBytes: file.size,
         }));
@@ -311,7 +311,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
             peersConnected: torrent.connected_downloading,
             peersTotal: torrent.total_downloading,
             percentComplete:
-              torrent.total_length > 0 ? Math.round((torrent.completed / torrent.selected_size) * 10000) / 100 : 0,
+              torrent.total_length > 0 ? Math.floor((torrent.completed / torrent.selected_size) * 10000) / 100 : 0,
             priority: 1,
             ratio:
               torrent.upload_total > 0 && torrent.download_total > 0

--- a/server/services/rTorrent/util/numberUtils.ts
+++ b/server/services/rTorrent/util/numberUtils.ts
@@ -1,6 +1,6 @@
 const truncateTo = (num: number, precision = 0) => {
   const factor = 10 ** precision;
-  return Math.round(num * factor) / factor;
+  return Math.floor(num * factor) / factor;
 };
 
 export default truncateTo;


### PR DESCRIPTION
Math.round can incorrectly round up 99.995% to 100.00%, showing a torrent as complete before it actually finishes. Math.floor ensures 100% is only displayed when truly complete.

This reverts core logic from #1179 in:
- `server/services/rTorrent/util/numberUtils.ts`: truncateTo function
- `server/services/Neptune/clientGatewayService.ts`: file-level and torrent-level percentComplete

Also fixes the `truncateTo` function name/implementation mismatch — it was named 'truncate' but used `Math.round`.