### PR TITLE
deps: update @trim21/neptune to 0.1.0-dev.799

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@storybook/addon-onboarding": "^9.1.20",
     "@storybook/react-vite": "^9.1.20",
     "@storybook/test-runner": "^0.23.0",
-    "@trim21/neptune": "0.1.0-dev.779",
+    "@trim21/neptune": "0.1.0-dev.799",
     "@types/bencode": "^2.0.4",
     "@types/content-disposition": "^0.5.9",
     "@types/create-torrent": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^0.23.0
         version: 0.23.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@2.8.8)(vite@6.4.3(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)))(ts-node@10.9.2(@swc/core@1.15.32)(@types/node@22.19.17)(typescript@5.0.4))
       '@trim21/neptune':
-        specifier: 0.1.0-dev.779
-        version: 0.1.0-dev.779
+        specifier: 0.1.0-dev.799
+        version: 0.1.0-dev.799
       '@types/bencode':
         specifier: ^2.0.4
         version: 2.0.4
@@ -2515,8 +2515,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@trim21/neptune@0.1.0-dev.779':
-    resolution: {integrity: sha512-4RgBpCk9u+sfOxeTJ7E+SC2uwcJFfh9/4pXwfVMDFK8zlLgIVTA2xVxgq/gz2VhHGBBjtrrJRXlh+cjHKYCVaA==}
+  '@trim21/neptune@0.1.0-dev.799':
+    resolution: {integrity: sha512-pbaxLDOBjo/EbM1xIwI0YDwhLhxVyfoamqh3N21k+vlri7yswpywgkumy7LmKvJZVabzI33A4ClJWtUK3TO24g==}
     engines: {node: '>=22.0.0'}
 
   '@ts-morph/common@0.29.0':
@@ -9888,7 +9888,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@trim21/neptune@0.1.0-dev.779': {}
+  '@trim21/neptune@0.1.0-dev.799': {}
 
   '@ts-morph/common@0.29.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,5 @@ allowBuilds:
   '@swc/core': true
   esbuild: true
 minimumReleaseAgeExclude:
-  - '@trim21/neptune@0.1.0-dev.779'
+  - '@trim21/neptune@0.1.0-dev.798'
+  - '@trim21/neptune@0.1.0-dev.799'

--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -322,7 +322,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
             sizeBytes: torrent.total_length,
             selectedSizeBytes: torrent.selected_size,
             status: getTorrentStatusFromState(
-              torrent.state as TorrentState,
+              torrent.state as (typeof TorrentState)[keyof typeof TorrentState],
               combinedMessage,
               torrent.download_rate,
               torrent.upload_rate,

--- a/server/services/Neptune/util/torrentPropertiesUtil.ts
+++ b/server/services/Neptune/util/torrentPropertiesUtil.ts
@@ -1,4 +1,4 @@
-import type {TorrentState} from '@trim21/neptune';
+import {TorrentState} from '@trim21/neptune';
 
 import type {TorrentProperties} from '../../../../shared/types/Torrent';
 import type {TorrentTracker} from '../../../../shared/types/TorrentTracker';
@@ -17,7 +17,7 @@ export const getTorrentTrackerTypeFromURL = (url: string): TorrentTracker['type'
 };
 
 export const getTorrentStatusFromState = (
-  state: TorrentState,
+  state: (typeof TorrentState)[keyof typeof TorrentState],
   message = '',
   downRate = 0,
   upRate = 0,
@@ -25,23 +25,24 @@ export const getTorrentStatusFromState = (
   const statuses: TorrentProperties['status'] = [];
 
   switch (state) {
-    case 'Stopped':
-      statuses.push('stopped');
-      break;
-    case 'Downloading':
+    case TorrentState.Downloading:
+    case TorrentState.PendingDownloading:
       statuses.push('downloading');
       break;
-    case 'Seeding':
+    case TorrentState.Seeding:
       statuses.push('complete');
       statuses.push('seeding');
       break;
-    case 'Checking':
+    case TorrentState.Checking:
       statuses.push('checking');
       break;
-    case 'Moving':
+    case TorrentState.Stopped:
+      statuses.push('stopped');
+      break;
+    case TorrentState.Moving:
       statuses.push('moving');
       break;
-    case 'Error':
+    case TorrentState.Error:
       statuses.push('error');
       statuses.push('stopped');
       break;


### PR DESCRIPTION
TorrentState is now exported as a const object with numeric values instead of string literals. Adapt `getTorrentStatusFromState` to use the enum-style values.

Also add `PendingDownloading` (state 2) case which was previously missing from the switch statement.