### PR TITLE
fix: migrate from deprecated disableRequestLogging to logController

### DIFF
--- a/server/routes/api/auth.test.ts
+++ b/server/routes/api/auth.test.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-import fastify from 'fastify';
+import fastify, {LogController} from 'fastify';
 import supertest from 'supertest';
 import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
 
@@ -40,7 +40,7 @@ const testNonAdminUser = {
 } as const;
 let testNonAdminUserToken = '';
 
-const app = fastify({disableRequestLogging: true, logger: true});
+const app = fastify({logController: new LogController({disableRequestLogging: true}), logger: true});
 let request: supertest.SuperTest<supertest.Test>;
 
 beforeAll(async () => {

--- a/server/routes/api/client.test.ts
+++ b/server/routes/api/client.test.ts
@@ -1,4 +1,4 @@
-import fastify from 'fastify';
+import fastify, {LogController} from 'fastify';
 import supertest from 'supertest';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
 
@@ -6,7 +6,7 @@ import type {ClientSettings} from '../../../shared/types/ClientSettings';
 import {getAuthToken} from '../../util/authUtil';
 import constructRoutes from '..';
 
-const app = fastify({disableRequestLogging: true, logger: true});
+const app = fastify({logController: new LogController({disableRequestLogging: true}), logger: true});
 let request: supertest.SuperTest<supertest.Test>;
 
 beforeAll(async () => {

--- a/server/routes/api/feed-monitor.test.ts
+++ b/server/routes/api/feed-monitor.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import fastify from 'fastify';
+import fastify, {LogController} from 'fastify';
 import supertest from 'supertest';
 import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
 
@@ -12,7 +12,7 @@ import constructRoutes from '..';
 
 vi.useRealTimers();
 
-const app = fastify({disableRequestLogging: true, logger: false});
+const app = fastify({logController: new LogController({disableRequestLogging: true}), logger: false});
 let request: supertest.SuperTest<supertest.Test>;
 
 beforeAll(async () => {

--- a/server/routes/api/index.test.ts
+++ b/server/routes/api/index.test.ts
@@ -1,4 +1,4 @@
-import fastify from 'fastify';
+import fastify, {LogController} from 'fastify';
 import supertest from 'supertest';
 import {afterAll, beforeAll, describe, expect, it, vi} from 'vitest';
 
@@ -8,7 +8,7 @@ import constructRoutes from '..';
 
 vi.useRealTimers();
 
-const app = fastify({disableRequestLogging: true, logger: false});
+const app = fastify({logController: new LogController({disableRequestLogging: true}), logger: false});
 let request: supertest.SuperTest<supertest.Test>;
 
 beforeAll(async () => {

--- a/server/routes/api/torrents.test.ts
+++ b/server/routes/api/torrents.test.ts
@@ -7,7 +7,7 @@ import stream from 'node:stream';
 
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import fastify from 'fastify';
+import fastify, {LogController} from 'fastify';
 import supertest from 'supertest';
 import {beforeAll, describe, expect, it} from 'vitest';
 
@@ -23,7 +23,11 @@ import {getTempPath} from '../../models/TemporaryStorage';
 import {getAuthToken} from '../../util/authUtil';
 import constructRoutes from '..';
 
-const app = fastify({bodyLimit: 100 * 1024 * 1024 * 1024, disableRequestLogging: true, forceCloseConnections: true});
+const app = fastify({
+  bodyLimit: 100 * 1024 * 1024 * 1024,
+  logController: new LogController({disableRequestLogging: true}),
+  forceCloseConnections: true,
+});
 let request: supertest.SuperTest<supertest.Test>;
 
 const activityStream = new stream.PassThrough();


### PR DESCRIPTION
## Summary

Replace deprecated top-level `disableRequestLogging` option with new `logController` API using `LogController` class from fastify.

Resolves FSTDEP023 deprecation warning.

## Changes

- Import `LogController` from `fastify` in test files
- Replace `{disableRequestLogging: true}` with `{logController: new LogController({disableRequestLogging: true})}`

## Test plan

- [ ] Run `pnpm test` and verify no FSTDEP023 warnings appear
- [ ] All existing tests pass
