### PR TITLE
fix: patch bencode exports field for Node.js v24 compatibility

### DIFF
--- a/patches/bencode@4.0.1.patch
+++ b/patches/bencode@4.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index 89dd4291874c9d5a49b06b4e63b4354d1212d93b..8e0527146bccb106001e42affa4e32d7cbdf612e 100644
+--- a/package.json
++++ b/package.json
+@@ -44,7 +44,7 @@
+     "node": ">=12.20.0"
+   },
+   "exports": {
+-    "import": "./index.js"
++    ".": "./index.js"
+   },
+   "repository": {
+     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  bencode@4.0.1: 2518f6f17ad50dfb3dd98826e75d43ba60d36e8c0a0116091c75d5f4536cd554
+
 importers:
 
   .:
@@ -196,7 +199,7 @@ importers:
         version: 2.1.0(axios@1.18.1)
       bencode:
         specifier: ^4.0.0
-        version: 4.0.1
+        version: 4.0.1(patch_hash=2518f6f17ad50dfb3dd98826e75d43ba60d36e8c0a0116091c75d5f4536cd554)
       chalk:
         specifier: ^5.0.0
         version: 5.6.2
@@ -11403,7 +11406,7 @@ snapshots:
 
   bencode@2.0.3: {}
 
-  bencode@4.0.1:
+  bencode@4.0.1(patch_hash=2518f6f17ad50dfb3dd98826e75d43ba60d36e8c0a0116091c75d5f4536cd554):
     dependencies:
       uint8-util: 2.2.6
 
@@ -11710,7 +11713,7 @@ snapshots:
 
   create-torrent@6.1.2:
     dependencies:
-      bencode: 4.0.1
+      bencode: 4.0.1(patch_hash=2518f6f17ad50dfb3dd98826e75d43ba60d36e8c0a0116091c75d5f4536cd554)
       block-iterator: 1.1.2
       fast-readable-async-iterator: 2.0.0
       is-file: 1.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,5 @@ allowBuilds:
   esbuild: true
   unrs-resolver: true
 minimumReleaseAgeStrict: false
+patchedDependencies:
+  bencode@4.0.1: patches/bencode@4.0.1.patch


### PR DESCRIPTION
## Description

bencode v4.0.1 has a malformed `exports` field in its `package.json`:

```json
"exports": { "import": "./index.js" }
```

This treats `"import"` as a **subpath** (`bencode/import`) instead of a condition, leaving the package root entry point (`import "bencode"`) undefined. Node.js v24 strictly enforces this and throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.

Upstream PR: https://github.com/webtorrent/node-bencode/pull/211

This PR applies a pnpm patch to fix the exports field until the upstream fix is merged and released. The patch changes the exports to use the correct subpath `"."`:

```json
"exports": { ".": "./index.js" }
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)