### PR TITLE
chore: patch uint8-util broken exports field

### DIFF
--- a/patches/uint8-util@2.2.6.patch
+++ b/patches/uint8-util@2.2.6.patch
@@ -1,0 +1,43 @@
+diff --git a/package.json b/package.json
+index 378ab0649a8048cd845971efb6eef154f83d4fc3..a8af2f8b126def4438ca252a9592e0e12b177ff0 100644
+--- a/package.json
++++ b/package.json
+@@ -7,21 +7,23 @@
+   "chromeapp": "browser.js",
+   "type": "module",
+   "exports": {
+-    "node": {
+-      "types": "./index.d.ts",
+-      "import": "./_node.js"
+-    },
+-    "browser": {
+-      "types": "./index.d.ts",
+-      "import": "./browser.js"
+-    },
+-    "chromeapp": {
+-      "types": "./index.d.ts",
+-      "import": "./browser.js"
+-    },
+-    "default": {
+-      "types": "./index.d.ts",
+-      "import": "./browser.js"
++    ".": {
++      "node": {
++        "types": "./index.d.ts",
++        "import": "./_node.js"
++      },
++      "browser": {
++        "types": "./index.d.ts",
++        "import": "./browser.js"
++      },
++      "chromeapp": {
++        "types": "./index.d.ts",
++        "import": "./browser.js"
++      },
++      "default": {
++        "types": "./index.d.ts",
++        "import": "./browser.js"
++      }
+     }
+   },
+   "types": "./index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 patchedDependencies:
   bencode@4.0.1: 2518f6f17ad50dfb3dd98826e75d43ba60d36e8c0a0116091c75d5f4536cd554
+  uint8-util@2.2.6: e725912d38476ff55b3c6275a17539fa5e8041bfe1ee91e256390c926c26f314
 
 importers:
 
@@ -10393,7 +10394,7 @@ snapshots:
 
   '@thaunknown/thirty-two@1.0.5':
     dependencies:
-      uint8-util: 2.2.6
+      uint8-util: 2.2.6(patch_hash=e725912d38476ff55b3c6275a17539fa5e8041bfe1ee91e256390c926c26f314)
 
   '@trim21/neptune@0.1.0-dev.876': {}
 
@@ -11389,7 +11390,7 @@ snapshots:
 
   bencode@4.0.1(patch_hash=2518f6f17ad50dfb3dd98826e75d43ba60d36e8c0a0116091c75d5f4536cd554):
     dependencies:
-      uint8-util: 2.2.6
+      uint8-util: 2.2.6(patch_hash=e725912d38476ff55b3c6275a17539fa5e8041bfe1ee91e256390c926c26f314)
 
   bep53-range@2.0.1: {}
 
@@ -11703,7 +11704,7 @@ snapshots:
       piece-length: 2.0.1
       queue-microtask: 1.2.3
       run-parallel: 1.2.0
-      uint8-util: 2.2.6
+      uint8-util: 2.2.6(patch_hash=e725912d38476ff55b3c6275a17539fa5e8041bfe1ee91e256390c926c26f314)
 
   cross-fetch-ponyfill@1.0.3:
     dependencies:
@@ -13908,7 +13909,7 @@ snapshots:
     dependencies:
       '@thaunknown/thirty-two': 1.0.5
       bep53-range: 2.0.1
-      uint8-util: 2.2.6
+      uint8-util: 2.2.6(patch_hash=e725912d38476ff55b3c6275a17539fa5e8041bfe1ee91e256390c926c26f314)
 
   make-dir@3.1.0:
     dependencies:
@@ -14565,7 +14566,7 @@ snapshots:
       get-stdin: 10.0.0
       magnet-uri: 7.0.8
       queue-microtask: 1.2.3
-      uint8-util: 2.2.6
+      uint8-util: 2.2.6(patch_hash=e725912d38476ff55b3c6275a17539fa5e8041bfe1ee91e256390c926c26f314)
 
   parseurl@1.3.3: {}
 
@@ -15910,7 +15911,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  uint8-util@2.2.6:
+  uint8-util@2.2.6(patch_hash=e725912d38476ff55b3c6275a17539fa5e8041bfe1ee91e256390c926c26f314):
     dependencies:
       base64-arraybuffer: 1.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,4 @@ allowBuilds:
 minimumReleaseAgeStrict: false
 patchedDependencies:
   bencode@4.0.1: patches/bencode@4.0.1.patch
+  uint8-util@2.2.6: patches/uint8-util@2.2.6.patch


### PR DESCRIPTION
`uint8-util@2.2.6` has a broken `exports` field — conditional exports (`node`, `browser`, etc.) are placed at the top level instead of under a `"."` entry point. Node.js treats these as subpath exports, causing import resolution failures.

This patches the dependency while waiting for upstream [PR #7](https://github.com/ThaUnknown/uint8-util/pull/7) to be merged.