### PR TITLE
chore(deps): upgrade CI dependencies

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: pnpm/action-setup@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs['node-version'] }}
           cache: pnpm

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/build-docker-distroless.yml
+++ b/.github/workflows/build-docker-distroless.yml
@@ -41,7 +41,7 @@ jobs:
 
     services:
       registry:
-        image: registry:2
+        image: registry:3
         ports:
           - 5000:5000
         options: >-

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,7 +51,7 @@ jobs:
 
     services:
       registry:
-        image: registry:2
+        image: registry:3
         ports:
           - 5000:5000
         options: >-

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,13 +30,13 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
           cache: pnpm

--- a/.github/workflows/publish-rolling.yml
+++ b/.github/workflows/publish-rolling.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "path=$(ls artifacts/*.tgz)" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo "path=$(ls artifacts/*.tgz)" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v46.1.18
+        uses: renovatebot/github-action@v46.1.19
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-backend-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -22,7 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v6
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/update-mmdb.yaml
+++ b/.github/workflows/update-mmdb.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 


### PR DESCRIPTION
## Summary
Combined dependency upgrades for CI workflows:

- Update renovatebot/github-action from v46.1.18 to v46.1.19
- Update actions/checkout from v4 to v7
- Update actions/setup-node from v6 to v7
- Update github/codeql-action from v3 to v4
- Update registry docker image from v2 to v3
- Update ubuntu runner from 22.04 to 24.04

## Changes
- 13 workflow files updated
- All changes are backward compatible
- No breaking changes expected