### PR TITLE
fix: replace deprecated Zod APIs for v4 compatibility

### DIFF
--- a/server/routes/api/auth.ts
+++ b/server/routes/api/auth.ts
@@ -290,7 +290,7 @@ const authRoutes = async (fastify: FastifyInstance) => {
                 z
                   .object({
                     username: z.string(),
-                    level: z.nativeEnum(AccessLevel),
+                    level: z.enum(AccessLevel),
                   })
                   .strict(),
               ),

--- a/shared/schema/Auth.ts
+++ b/shared/schema/Auth.ts
@@ -1,30 +1,32 @@
 import type {infer as zodInfer} from 'zod';
-import {literal, nativeEnum, number, strictObject, string, union} from 'zod';
+import z from 'zod';
 
 import {clientConnectionSettingsSchema} from './ClientConnectionSettings';
 import {AccessLevel} from './constants/Auth';
 
-export const authMethodSchema = union([literal('default'), literal('none')]);
+export const authMethodSchema = z.union([z.literal('default'), z.literal('none')]);
 
 export type AuthMethod = zodInfer<typeof authMethodSchema>;
 
-export const credentialsSchema = strictObject({
-  username: string(),
-  password: string(),
-  client: clientConnectionSettingsSchema,
-  level: nativeEnum(AccessLevel),
-}).strip();
+export const credentialsSchema = z
+  .strictObject({
+    username: z.string(),
+    password: z.string(),
+    client: clientConnectionSettingsSchema,
+    level: z.enum(AccessLevel),
+  })
+  .strip();
 
 export type Credentials = zodInfer<typeof credentialsSchema>;
 
 export type UserInDatabase = Required<Credentials> & {_id: string; timestamp: number};
 
-export const authTokenSchema = strictObject({
-  username: string(),
+export const authTokenSchema = z.strictObject({
+  username: z.string(),
   // issued at
-  iat: number(),
+  iat: z.number(),
   // expiration
-  exp: number(),
+  exp: z.number(),
 });
 
 export type AuthToken = zodInfer<typeof authTokenSchema>;

--- a/shared/schema/ClientConnectionSettings.ts
+++ b/shared/schema/ClientConnectionSettings.ts
@@ -1,5 +1,5 @@
 import type {infer as zodInfer} from 'zod';
-import {literal, number, strictObject, string, union} from 'zod';
+import {literal, number, strictObject, string, union, url} from 'zod';
 
 const delugeConnectionSettingsSchema = strictObject({
   client: literal('Deluge'),
@@ -17,7 +17,7 @@ const qBittorrentConnectionSettingsSchema = strictObject({
   client: literal('qBittorrent'),
   type: literal('web'),
   version: literal(1),
-  url: string().url(),
+  url: url(),
   username: string(),
   password: string(),
 });
@@ -54,7 +54,7 @@ const transmissionConnectionSettingsSchema = strictObject({
   client: literal('Transmission'),
   type: literal('rpc'),
   version: literal(1),
-  url: string().url(),
+  url: url(),
   username: string(),
   password: string(),
 });
@@ -65,7 +65,7 @@ const neptuneConnectionSettingsSchema = strictObject({
   client: literal('Neptune'),
   type: literal('rpc'),
   version: literal(1),
-  url: string().url(),
+  url: url(),
   token: string(),
 });
 

--- a/shared/schema/api/auth.ts
+++ b/shared/schema/api/auth.ts
@@ -16,11 +16,10 @@ export type AuthAuthenticationOptions = zodInfer<typeof authAuthenticationRequir
 export const authAuthenticationSchema = authAuthenticationRequiredSchema;
 
 export const authAuthenticationRequestSchema = z
-  .object({
+  .looseObject({
     username: z.string().nullable().optional(),
     password: z.string().nullable().optional(),
   })
-  .passthrough()
   .optional();
 export type AuthAuthenticationRequestOptions = zodInfer<typeof authAuthenticationRequestSchema>;
 
@@ -35,7 +34,7 @@ export const authAuthenticationResponseSchema = z
   .object({
     success: z.literal(true),
     username: z.string(),
-    level: z.nativeEnum(AccessLevel),
+    level: z.enum(AccessLevel),
   })
   .strict();
 
@@ -97,7 +96,7 @@ export const authVerificationResponseSchema = z.union([
     .object({
       initialUser: z.literal(false),
       username: z.string(),
-      level: z.nativeEnum(AccessLevel),
+      level: z.enum(AccessLevel),
       configs: authVerificationPreloadConfigsSchema,
     })
     .strict(),


### PR DESCRIPTION
Replace deprecated Zod APIs with their Zod v4 equivalents:

- `z.string().url()` → `z.url()`
- `z.nativeEnum()` → `z.enum()` (merged into  in v4)
- `.passthrough()` → `.looseObject()`