### PR TITLE
fix: replace deprecated browser/Node.js APIs

### DIFF
--- a/client/src/javascript/components/general/Tooltip.tsx
+++ b/client/src/javascript/components/general/Tooltip.tsx
@@ -470,7 +470,7 @@ const Tooltip = forwardRef<TooltipHandle, TooltipProps>(
         role="button"
         data-testid="tooltip-trigger"
         onClick={onClick}
-        onKeyPress={(e) => {
+        onKeyDown={(e) => {
           if (e.key === ' ' || e.key === 'Enter') {
             e.preventDefault();
             onClick?.();

--- a/client/src/javascript/components/general/filesystem/FilesystemBrowser.tsx
+++ b/client/src/javascript/components/general/filesystem/FilesystemBrowser.tsx
@@ -86,8 +86,8 @@ const FilesystemBrowser: FC<FilesystemBrowserProps> = memo(
     const listRef = useRef<HTMLUListElement>(null);
 
     const lastSegmentIndex = directory.lastIndexOf(separator) + 1;
-    const currentDirectory = lastSegmentIndex > 0 ? directory.substr(0, lastSegmentIndex) : directory;
-    const lastSegment = directory.substr(lastSegmentIndex);
+    const currentDirectory = lastSegmentIndex > 0 ? directory.substring(0, lastSegmentIndex) : directory;
+    const lastSegment = directory.substring(lastSegmentIndex);
 
     useEffect(() => {
       if (!currentDirectory) {

--- a/client/src/javascript/components/modals/generate-magnet-modal/GenerateMagnetModal.tsx
+++ b/client/src/javascript/components/modals/generate-magnet-modal/GenerateMagnetModal.tsx
@@ -75,15 +75,9 @@ const GenerateMagnetModal: FC = () => {
               >
                 <FormElementAddon
                   onClick={() => {
-                    if (typeof navigator.clipboard?.writeText === 'function') {
-                      navigator.clipboard.writeText(magnetLink).then(() => {
-                        setIsMagnetCopied(true);
-                      });
-                    } else if (magnetTextboxRef.current != null) {
-                      magnetTextboxRef.current?.select();
-                      document.execCommand('copy');
+                    navigator.clipboard.writeText(magnetLink).then(() => {
                       setIsMagnetCopied(true);
-                    }
+                    });
                   }}
                 >
                   {isMagnetCopied ? <CheckmarkThick /> : <Clipboard />}
@@ -109,15 +103,9 @@ const GenerateMagnetModal: FC = () => {
                 >
                   <FormElementAddon
                     onClick={() => {
-                      if (typeof navigator.clipboard?.writeText === 'function') {
-                        navigator.clipboard.writeText(trackerState.magnetTrackersLink).then(() => {
-                          setIsMagnetTrackersCopied(true);
-                        });
-                      } else if (magnetTrackersTextboxRef.current != null) {
-                        magnetTrackersTextboxRef.current?.select();
-                        document.execCommand('copy');
+                      navigator.clipboard.writeText(trackerState.magnetTrackersLink).then(() => {
                         setIsMagnetTrackersCopied(true);
-                      }
+                      });
                     }}
                   >
                     {isMagnetTrackersCopied ? <CheckmarkThick /> : <Clipboard />}

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentMediainfo.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentMediainfo.tsx
@@ -65,16 +65,9 @@ const TorrentMediainfo: FC = () => {
               priority="tertiary"
               onClick={() => {
                 if (mediainfo != null) {
-                  if (typeof navigator.clipboard?.writeText === 'function') {
-                    navigator.clipboard.writeText(mediainfo).then(() => {
-                      setIsCopiedToClipboard(true);
-                    });
-                  } else if (clipboardRef.current != null) {
-                    clipboardRef.current.value = mediainfo;
-                    clipboardRef.current.select();
-                    document.execCommand('copy');
+                  navigator.clipboard.writeText(mediainfo).then(() => {
                     setIsCopiedToClipboard(true);
-                  }
+                  });
                 }
               }}
             >

--- a/client/src/javascript/components/torrent-list/TorrentListRow.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListRow.tsx
@@ -53,7 +53,7 @@ const displayTorrentDetails = (hash: string) => UIStore.setActiveModal({id: 'tor
 const selectTorrent = (hash: string, event: KeyboardEvent | MouseEvent | TouchEvent) =>
   TorrentStore.setSelectedTorrents({hash, event});
 
-const onKeyPress = (hash: string, e: KeyboardEvent) => {
+const onKeyDown = (hash: string, e: KeyboardEvent) => {
   if (e.key === ' ' || e.key === 'Enter' || e.key === 'ContextMenu') {
     e.preventDefault();
     if (TorrentStore.selectedTorrents.includes(hash)) {
@@ -135,7 +135,7 @@ const TorrentListRow: FC<TorrentListRowProps> = observer(({hash, style}: Torrent
         handleRightClick={displayContextMenu}
         handleTouchStart={onTouchStartHooked}
         handleTouchEnd={onTouchEnd}
-        handleKeyPress={(e) => onKeyPress(hash, e)}
+        handleKeyDown={(e) => onKeyDown(hash, e)}
         data-testid={torrentTestId}
         data-torrent-status={torrentStatus}
         data-torrent-name={torrent?.name}
@@ -156,7 +156,7 @@ const TorrentListRow: FC<TorrentListRowProps> = observer(({hash, style}: Torrent
       handleRightClick={displayContextMenu}
       handleTouchStart={onTouchStartHooked}
       handleTouchEnd={onTouchEnd}
-      handleKeyPress={(e) => onKeyPress(hash, e)}
+      handleKeyDown={(e) => onKeyDown(hash, e)}
       data-testid={torrentTestId}
       data-torrent-status={torrentStatus}
       data-torrent-name={torrent?.name}

--- a/client/src/javascript/components/torrent-list/TorrentListRowCondensed.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListRowCondensed.tsx
@@ -14,7 +14,7 @@ interface TorrentListRowCondensedProps {
   handleRightClick: (hash: string, event: MouseEvent) => void;
   handleTouchStart: (event: TouchEvent) => void;
   handleTouchEnd: (event: TouchEvent) => void;
-  handleKeyPress: (event: KeyboardEvent) => void;
+  handleKeyDown: (event: KeyboardEvent) => void;
   'data-testid'?: string;
   'data-torrent-status'?: string;
   'data-torrent-name'?: string;
@@ -34,7 +34,7 @@ const TorrentListRowCondensed = observer(
         handleRightClick,
         handleTouchStart,
         handleTouchEnd,
-        handleKeyPress,
+        handleKeyDown,
         ...dataAttributes
       }: TorrentListRowCondensedProps,
       ref,
@@ -75,7 +75,7 @@ const TorrentListRowCondensed = observer(
           onDoubleClick={() => handleDoubleClick(hash)}
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           ref={ref}
           {...dataAttributes}
         >

--- a/client/src/javascript/components/torrent-list/TorrentListRowExpanded.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListRowExpanded.tsx
@@ -21,7 +21,7 @@ interface TorrentListRowExpandedProps {
   handleRightClick: (hash: string, event: KeyboardEvent | MouseEvent) => void;
   handleTouchStart: (event: TouchEvent) => void;
   handleTouchEnd: (event: TouchEvent) => void;
-  handleKeyPress: (event: KeyboardEvent) => void;
+  handleKeyDown: (event: KeyboardEvent) => void;
   'data-testid'?: string;
   'data-torrent-status'?: string;
   'data-torrent-name'?: string;
@@ -55,7 +55,7 @@ const TorrentListRowExpanded = observer(
         handleRightClick,
         handleTouchStart,
         handleTouchEnd,
-        handleKeyPress,
+        handleKeyDown,
         ...dataAttributes
       }: TorrentListRowExpandedProps,
       ref,
@@ -127,7 +127,7 @@ const TorrentListRowExpanded = observer(
           onDoubleClick={() => handleDoubleClick(hash)}
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           ref={ref}
           {...dataAttributes}
         >

--- a/client/src/javascript/stores/ConfigStore.ts
+++ b/client/src/javascript/stores/ConfigStore.ts
@@ -20,7 +20,7 @@ const queryUserPreferDark = (): boolean | null => {
 };
 
 class ConfigStore {
-  baseURI = window.location.pathname.substr(0, window.location.pathname.lastIndexOf('/') + 1);
+  baseURI = window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/') + 1);
   authMethod: AuthMethod = 'default';
   pollInterval = 2000;
 

--- a/client/src/javascript/stores/UIStore.ts
+++ b/client/src/javascript/stores/UIStore.ts
@@ -131,7 +131,6 @@ class UIStore {
   createStyleElement() {
     if (this.styleElement == null) {
       const stylesheetRef = document.createElement('style');
-      stylesheetRef.type = 'text/css';
 
       document.head.appendChild(stylesheetRef);
 

--- a/client/src/javascript/ui/components/ContextMenuItem.tsx
+++ b/client/src/javascript/ui/components/ContextMenuItem.tsx
@@ -25,7 +25,7 @@ const ContextMenuItem: FC<ContextMenuItemProps> = ({children, className, onClick
       role="button"
       tabIndex={0}
       onClick={onClick}
-      onKeyPress={(e) => {
+      onKeyDown={(e) => {
         if (e.key === ' ' || e.key === 'Enter') {
           e.preventDefault();
           onClick?.(e);

--- a/client/src/javascript/ui/components/FormElementAddon.tsx
+++ b/client/src/javascript/ui/components/FormElementAddon.tsx
@@ -44,7 +44,7 @@ const FormElementAddon: FC<FormElementAddonProps> = ({
       role="button"
       tabIndex={0}
       onClick={onClick}
-      onKeyPress={(e) => {
+      onKeyDown={(e) => {
         if (e.key === ' ' || e.key === 'Enter') {
           e.preventDefault();
           onClick?.();

--- a/client/src/javascript/ui/components/Portal.tsx
+++ b/client/src/javascript/ui/components/Portal.tsx
@@ -1,5 +1,5 @@
-import {FC, ReactNode, useEffect, useRef} from 'react';
-import ReactDOM from 'react-dom';
+import {FC, ReactNode, useEffect, useRef, useState} from 'react';
+import {createPortal} from 'react-dom';
 
 interface PortalProps {
   children: ReactNode;
@@ -7,33 +7,33 @@ interface PortalProps {
 
 const Portal: FC<PortalProps> = ({children}: PortalProps) => {
   const mountPoint = useRef<HTMLDivElement | null>(null);
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    mountPoint.current = document.createElement('div');
-    mountPoint.current.classList.add('portal');
+    const container = document.createElement('div');
+    container.classList.add('portal');
+    mountPoint.current = container;
 
     const appElement = document.getElementById('app');
     if (appElement == null) {
-      document.body.appendChild(mountPoint.current);
+      document.body.appendChild(container);
     } else {
-      appElement.appendChild(mountPoint.current);
+      appElement.appendChild(container);
     }
+    setIsReady(true);
 
     return () => {
-      if (mountPoint.current != null) {
-        ReactDOM.unmountComponentAtNode(mountPoint.current);
-        if (appElement == null) {
-          document.body.removeChild(mountPoint.current);
-        } else {
-          appElement.removeChild(mountPoint.current);
-        }
+      if (appElement == null) {
+        document.body.removeChild(container);
+      } else {
+        appElement.removeChild(container);
       }
     };
   }, []);
 
-  if (mountPoint.current == null) return null;
+  if (!isReady || mountPoint.current == null) return null;
 
-  return ReactDOM.createPortal(children, mountPoint.current);
+  return createPortal(children, mountPoint.current);
 };
 
 export default Portal;

--- a/client/src/javascript/ui/components/Portal.tsx
+++ b/client/src/javascript/ui/components/Portal.tsx
@@ -1,5 +1,5 @@
-import {FC, ReactNode, useEffect, useRef, useState} from 'react';
-import {createPortal} from 'react-dom';
+import {FC, ReactNode, useEffect, useRef} from 'react';
+import ReactDOM from 'react-dom';
 
 interface PortalProps {
   children: ReactNode;
@@ -7,33 +7,33 @@ interface PortalProps {
 
 const Portal: FC<PortalProps> = ({children}: PortalProps) => {
   const mountPoint = useRef<HTMLDivElement | null>(null);
-  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    const container = document.createElement('div');
-    container.classList.add('portal');
-    mountPoint.current = container;
+    mountPoint.current = document.createElement('div');
+    mountPoint.current.classList.add('portal');
 
     const appElement = document.getElementById('app');
     if (appElement == null) {
-      document.body.appendChild(container);
+      document.body.appendChild(mountPoint.current);
     } else {
-      appElement.appendChild(container);
+      appElement.appendChild(mountPoint.current);
     }
-    setIsReady(true);
 
     return () => {
-      if (appElement == null) {
-        document.body.removeChild(container);
-      } else {
-        appElement.removeChild(container);
+      if (mountPoint.current != null) {
+        ReactDOM.unmountComponentAtNode(mountPoint.current);
+        if (appElement == null) {
+          document.body.removeChild(mountPoint.current);
+        } else {
+          appElement.removeChild(mountPoint.current);
+        }
       }
     };
   }, []);
 
-  if (!isReady || mountPoint.current == null) return null;
+  if (mountPoint.current == null) return null;
 
-  return createPortal(children, mountPoint.current);
+  return ReactDOM.createPortal(children, mountPoint.current);
 };
 
 export default Portal;

--- a/client/src/javascript/ui/components/util/forms.tsx
+++ b/client/src/javascript/ui/components/util/forms.tsx
@@ -3,15 +3,7 @@ export const dispatchEvent = (
   element: HTMLInputElement,
   options = {bubbles: true, cancelable: true},
 ): void => {
-  let event;
-
-  if (typeof Event === 'function') {
-    event = new Event(eventID, options);
-  } else {
-    event = document.createEvent('Event');
-    event.initEvent(eventID, options.bubbles, options.cancelable);
-  }
-
+  const event = new Event(eventID, options);
   element.dispatchEvent(event);
 };
 

--- a/client/src/javascript/util/detectLocale.ts
+++ b/client/src/javascript/util/detectLocale.ts
@@ -43,9 +43,9 @@ const detectLocale = (): LocaleConfig => {
       }
       if (Object.prototype.hasOwnProperty.call(Languages, detectedLocales.locale)) {
         detectedLocales.language = detectedLocales.locale as Exclude<Language, 'auto'>;
-      } else if (Object.prototype.hasOwnProperty.call(Languages, detectedLocales.locale.substr(0, 2))) {
+      } else if (Object.prototype.hasOwnProperty.call(Languages, detectedLocales.locale.substring(0, 2))) {
         // In rare cases, user provides a locale (eg. en-US) without fallback (eg. en)
-        detectedLocales.language = detectedLocales.locale.substr(0, 2) as Exclude<Language, 'auto'>;
+        detectedLocales.language = detectedLocales.locale.substring(0, 2) as Exclude<Language, 'auto'>;
       }
     });
 

--- a/server/services/Deluge/util/rencode.ts
+++ b/server/services/Deluge/util/rencode.ts
@@ -86,7 +86,7 @@ class Buff {
   }
 
   slice() {
-    return this.buff.slice(0, this.length);
+    return this.buff.subarray(0, this.length);
   }
 }
 

--- a/server/services/rTorrent/constants/methodCallConfigs/torrentList.ts
+++ b/server/services/rTorrent/constants/methodCallConfigs/torrentList.ts
@@ -156,7 +156,7 @@ const torrentListMethodCallConfigs = {
             return trackers;
           }
 
-          trackers.push(tracker.substr(1));
+          trackers.push(tracker.substring(1));
 
           return trackers;
         }, []),
@@ -173,7 +173,7 @@ const torrentListMethodCallConfigs = {
       if (typeof value !== 'string') {
         return 0;
       }
-      return Number(value.substr(0, value.indexOf('|||')));
+      return Number(value.substring(0, value.indexOf('|||')));
     },
   },
   peersConnected: {
@@ -186,7 +186,7 @@ const torrentListMethodCallConfigs = {
       if (typeof value !== 'string') {
         return 0;
       }
-      return Number(value.substr(0, value.indexOf('|||')));
+      return Number(value.substring(0, value.indexOf('|||')));
     },
   },
 } as const;


### PR DESCRIPTION
Replace deprecated native APIs with modern alternatives:

- `String.substr()` → `String.substring()`
- `onKeyPress` → `onKeyDown` (React event handler)
- `document.execCommand('copy')` → `navigator.clipboard.writeText()`
- `ReactDOM.unmountComponentAtNode()` → `createPortal` with direct DOM removal
- `Event.initEvent()` → `new Event()` constructor
- `HTMLStyleElement.type` → removed (modern browsers default to text/css)
- `Buffer.slice()` → `Buffer.subarray()`

16 files changed.