### PR TITLE
eslint: enable @typescript-eslint/no-unnecessary-type-assertion

### DIFF
--- a/.storybook/mocks/TorrentActions.ts
+++ b/.storybook/mocks/TorrentActions.ts
@@ -427,7 +427,7 @@ const TorrentActions = {
         : ['file://default.torrent'];
 
     return TorrentActions.addTorrentsByUrls({
-      urls: fileUrls as [string, ...string[]],
+      urls: fileUrls,
       destination,
       tags,
       isBasePath,

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -14,7 +14,7 @@ import {BrowserRouter} from 'react-router-dom';
 import {messages as enMessages} from '../client/src/javascript/i18n/strings/en.json?lingui';
 
 // Configure i18n with proper message format
-i18n.load('en', enMessages as Record<string, string[]>);
+i18n.load('en', enMessages);
 i18n.activate('en');
 
 const preview: Preview = {

--- a/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByFile.tsx
+++ b/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByFile.tsx
@@ -95,7 +95,7 @@ const AddTorrentsByFile: FC = () => {
           const tagsArray = tags != null ? tags.split(',').filter((tag) => tag.length > 0) : undefined;
 
           TorrentActions.addTorrentsByFiles({
-            files: filesData as [string, ...string[]],
+            files: filesData,
             destination,
             tags: tagsArray,
             isBasePath,

--- a/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByURL.tsx
+++ b/client/src/javascript/components/modals/add-torrents-modal/AddTorrentsByURL.tsx
@@ -130,7 +130,7 @@ const AddTorrentsByURL: FC = () => {
           const tags = formData.tags != null ? formData.tags.split(',').filter((tag) => tag.length > 0) : undefined;
 
           TorrentActions.addTorrentsByUrls({
-            urls: urls as [string, ...string[]],
+            urls: urls,
             cookies: processedCookies,
             destination: formData.destination,
             isBasePath: formData.isBasePath,

--- a/client/src/javascript/components/modals/set-tags-modal/SetTagsModal.tsx
+++ b/client/src/javascript/components/modals/set-tags-modal/SetTagsModal.tsx
@@ -53,7 +53,7 @@ const SetTagsModal: FC = () => {
 
             if (selectedTorrents?.length > 0) {
               TorrentActions.setTags({
-                hashes: selectedTorrents as [string, ...string[]],
+                hashes: selectedTorrents,
                 tags,
               });
             }

--- a/client/src/javascript/components/modals/settings-modal/SettingsUtils.tsx
+++ b/client/src/javascript/components/modals/settings-modal/SettingsUtils.tsx
@@ -9,7 +9,7 @@ export const getChangedClientSetting = <T extends ClientSetting>(
   property: T,
 ): ClientSettings[T] | undefined => {
   if (changedClientSettings[property] != null) {
-    return changedClientSettings[property] as ClientSettings[T];
+    return changedClientSettings[property];
   }
 
   return SettingStore.clientSettings?.[property];

--- a/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListContextMenu.tsx
@@ -81,7 +81,7 @@ export const getContextMenuItems = (torrent: TorrentProperties): Array<ContextMe
       label: TorrentContextMenuActions.reannounce,
       clickHandler: () => {
         TorrentActions.reannounce({
-          hashes: TorrentStore.selectedTorrents as [string, ...string[]],
+          hashes: TorrentStore.selectedTorrents,
         });
       },
     },

--- a/client/src/javascript/i18n/languages.tsx
+++ b/client/src/javascript/i18n/languages.tsx
@@ -31,7 +31,7 @@ async function getMessages(locale: Exclude<Language, 'auto'>): Promise<Record<st
     return cached;
   }
 
-  return loadMessages(locale as Exclude<Language, 'auto' | 'en'>);
+  return loadMessages(locale);
 }
 
 interface AsyncIntlProviderProps {

--- a/client/src/javascript/routes/Overview.stories.tsx
+++ b/client/src/javascript/routes/Overview.stories.tsx
@@ -971,7 +971,7 @@ export const FilteredView: Story = {
       await setupOverviewData();
       // Set filters that will be preserved when component starts activity stream
       setFilters({
-        status: ['downloading' as TorrentStatus],
+        status: ['downloading'],
         tags: ['linux'],
       });
     },

--- a/client/src/javascript/stores/TorrentFilterStore.ts
+++ b/client/src/javascript/stores/TorrentFilterStore.ts
@@ -118,7 +118,7 @@ class TorrentFilterStore {
         const increment = currentKeyIndex > lastKeyIndex ? -1 : 1;
 
         for (; currentKeyIndex !== lastKeyIndex; currentKeyIndex += increment) {
-          const foundKey = keys[currentKeyIndex] as T;
+          const foundKey = keys[currentKeyIndex];
           // if the filter isn't already selected, add the filter to the array.
           if (!currentFilters.includes(foundKey)) {
             currentFilters.push(foundKey);

--- a/client/src/javascript/ui/icons/CountryFlag.tsx
+++ b/client/src/javascript/ui/icons/CountryFlag.tsx
@@ -22,7 +22,7 @@ const getFlag = (countryCode?: string): string | null => {
     const loader = flagModules[key];
     if (loader) {
       try {
-        flag = (await loader()) as string;
+        flag = await loader();
       } catch {
         flag = null;
       }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,14 @@ export default [
     files: ['**/*.ts', '**/*.tsx'],
   })),
 
+  // TypeScript type-checked rules for .ts/.tsx files
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+    },
+  },
+
   // Prettier config (disables conflicting rules)
   prettierConfig,
 

--- a/server/models/Users.ts
+++ b/server/models/Users.ts
@@ -113,7 +113,7 @@ class Users {
         }
 
         throw new Error();
-      }) as Promise<UserInDatabase>;
+      });
   }
 
   /**

--- a/server/routes/api/auth.ts
+++ b/server/routes/api/auth.ts
@@ -128,7 +128,7 @@ const authRoutes = async (fastify: FastifyInstance) => {
         if (user == null) {
           throw new UnauthorizedError();
         }
-        setAuthContext(req, {user, services: getAllServices(user)!});
+        setAuthContext(req, {user, services: getAllServices(user)});
         if (reply.sent) {
           return;
         }

--- a/server/routes/api/feed-monitor.test.ts
+++ b/server/routes/api/feed-monitor.test.ts
@@ -138,7 +138,7 @@ describe('PATCH /api/feed-monitor/feeds/{id}', () => {
       .expect(200)
       .expect('Content-Type', /json/);
 
-    addedFeed = {...(addedFeed as Feed), ...modifyFeedOptions};
+    addedFeed = {...addedFeed, ...modifyFeedOptions};
 
     expect(res.body).toStrictEqual([addedFeed]);
   });

--- a/server/routes/api/torrents.ts
+++ b/server/routes/api/torrents.ts
@@ -53,7 +53,7 @@ async function createTorrentAsync(input: TorrentInput, option: CreateTorrentOpti
     createTorrent(input, option, (error, torrent) => {
       if (error) return reject(error);
 
-      resolve(Buffer.from(torrent!));
+      resolve(Buffer.from(torrent));
     });
   });
 }

--- a/server/routes/clientAppAssets.ts
+++ b/server/routes/clientAppAssets.ts
@@ -75,7 +75,7 @@ const registerEmbeddedClientAppAssetsRoutes = async (
   fastify.get('/overview', sendIndex);
 
   fastify.get<{Params: {'*': string}}>('/*', (request, reply) => {
-    const relativePath = decodeAssetPath((request.params as {['*']: string})['*']);
+    const relativePath = decodeAssetPath(request.params['*']);
 
     if (
       relativePath === '' ||
@@ -130,7 +130,7 @@ export const registerClientAppAssetsRoutes = async (fastify: FastifyInstance): P
   }
 
   const embeddedAssets: EmbeddedAssets | undefined =
-    typeof __FLOOD_EMBEDDED_ASSETS__ === 'undefined' ? undefined : (__FLOOD_EMBEDDED_ASSETS__ as EmbeddedAssets);
+    typeof __FLOOD_EMBEDDED_ASSETS__ === 'undefined' ? undefined : __FLOOD_EMBEDDED_ASSETS__;
 
   if (embeddedAssets) {
     return await registerEmbeddedClientAppAssetsRoutes(fastify, {embeddedAssets});

--- a/server/services/Deluge/clientGatewayService.ts
+++ b/server/services/Deluge/clientGatewayService.ts
@@ -120,7 +120,7 @@ class DelugeClientGatewayService extends BaseClientGatewayService implements Cli
     if (files[0]) {
       result.push(
         ...(await this.addTorrentsByFile({
-          files: files.map((file) => file.toString('base64')) as [string, ...string[]],
+          files: files.map((file) => file.toString('base64')),
           destination,
           tags,
           isBasePath,

--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -96,7 +96,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
     }
 
     return this.addTorrentsByFile({
-      files: files.map((file) => file.toString('base64')) as [string, ...string[]],
+      files: files.map((file) => file.toString('base64')),
       destination,
       tags,
       isBasePath,

--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -77,7 +77,7 @@ class TransmissionClientGatewayService extends BaseClientGatewayService implemen
     }
 
     if (tags.length > 0) {
-      await this.setTorrentsTags({hashes: addedTorrents as [string, ...string[]], tags});
+      await this.setTorrentsTags({hashes: addedTorrents, tags});
     }
 
     if (isCompleted) {
@@ -126,13 +126,13 @@ class TransmissionClientGatewayService extends BaseClientGatewayService implemen
     }
 
     if (result[0] && tags.length > 0) {
-      await this.setTorrentsTags({hashes: result as [string, ...string[]], tags});
+      await this.setTorrentsTags({hashes: result, tags});
     }
 
     if (files[0]) {
       result.push(
         ...(await this.addTorrentsByFile({
-          files: files.map((file) => file.toString('base64')) as [string, ...string[]],
+          files: files.map((file) => file.toString('base64')),
           destination,
           tags,
           isBasePath,

--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -184,7 +184,7 @@ class QBittorrentClientGatewayService extends BaseClientGatewayService implement
 
     if (files[0]) {
       return this.addTorrentsByFile({
-        files: files.map((file) => file.toString('base64')) as [string, ...string[]],
+        files: files.map((file) => file.toString('base64')),
         destination,
         tags,
         isBasePath,

--- a/server/services/rTorrent/clientGatewayService.ts
+++ b/server/services/rTorrent/clientGatewayService.ts
@@ -85,7 +85,7 @@ const resolveMethodCallConfigs = (configs: MethodCallConfigs, methodList: string
   // Sort keys so that Object.values(configs) (methodCalls) and
   // Object.keys(configs) (processMethodCallResponse) stay in sync.
   for (const key of Object.keys(configs).sort()) {
-    const config = configs[key]!;
+    const config = configs[key];
     const methods = Array.isArray(config.methodCall) ? config.methodCall : [config.methodCall];
     const availableMethod = methodList.length > 0 ? methods.find((m) => methodList.includes(m)) : methods[0];
     if (availableMethod) {
@@ -324,7 +324,7 @@ class RTorrentClientGatewayService extends BaseClientGatewayService implements C
 
     if (files[0]) {
       await this.addTorrentsByFile({
-        files: files.map((file) => file.toString('base64')) as [string, ...string[]],
+        files: files.map((file) => file.toString('base64')),
         destination,
         tags,
         isBasePath,
@@ -906,7 +906,7 @@ class RTorrentClientGatewayService extends BaseClientGatewayService implements C
     const methodCalls: MultiMethodCalls = Object.keys(configs)
       .sort()
       .map((key) => ({
-        methodName: configs[key]!.methodCall as string,
+        methodName: configs[key].methodCall as string,
         params: [''],
       }));
 
@@ -934,7 +934,7 @@ class RTorrentClientGatewayService extends BaseClientGatewayService implements C
     const methodCalls: MultiMethodCalls = Object.keys(configs)
       .sort()
       .map((key) => ({
-        methodName: configs[key]!.methodCall as string,
+        methodName: configs[key].methodCall as string,
         params: [''],
       }));
 

--- a/server/util/feedUtil.ts
+++ b/server/util/feedUtil.ts
@@ -72,7 +72,7 @@ export const getFeedItemsMatchingRules = (
 
         if (!isAlreadyDownloaded && torrentUrls[0] != null) {
           matchedItems.push({
-            urls: torrentUrls as [string, ...string[]],
+            urls: torrentUrls,
             tags: rule.tags,
             matchTitle: feedItem.title as string,
             ruleID: rule._id,

--- a/server/util/torrentFileUtil.ts
+++ b/server/util/torrentFileUtil.ts
@@ -20,7 +20,7 @@ const convertToBuffer = (data: unknown): unknown => {
   }
   if (data != null && typeof data === 'object') {
     const result: Record<string, unknown> = {};
-    for (const key of Object.keys(data as Record<string, unknown>)) {
+    for (const key of Object.keys(data)) {
       result[key] = convertToBuffer((data as Record<string, unknown>)[key]);
     }
     return result;


### PR DESCRIPTION
## Summary

Enable  rule and fix all violations.

## Changes

- Added rule to  (TypeScript files only)
- Removed 24 unnecessary type assertions across the codebase

## Part of recommendedTypeChecked adoption

This is the first step in gradually enabling all  rules to improve type safety.