### PR TITLE
eslint: enable all recommendedTypeChecked rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,13 +34,13 @@ export default [
     files: ['**/*.ts', '**/*.tsx'],
   })),
 
-  // TypeScript type-checked rules for .ts/.tsx files
-  {
-    files: ['**/*.ts', '**/*.tsx'],
-    rules: {
-      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-    },
-  },
+  // TypeScript type-checked rules for .ts/.tsx files - all recommendedTypeChecked rules
+  ...typescriptEslint.configs.recommendedTypeChecked
+    .filter((config) => config.rules)
+    .map((config) => ({
+      ...config,
+      files: ['**/*.ts', '**/*.tsx'],
+    })),
 
   // Prettier config (disables conflicting rules)
   prettierConfig,


### PR DESCRIPTION
## Summary

Enable all `@typescript-eslint/recommendedTypeChecked` rules.

## Changes

- Added all recommendedTypeChecked rules to eslint config
- Auto-fixable violations have been resolved

## Remaining violations (312 in production code)

These require manual fixes and will be addressed in follow-up PRs:

| Rule | Count |
|------|-------|
| no-floating-promises | 76 |
| no-unsafe-assignment | 60 |
| require-await | 35 |
| no-unsafe-argument | 35 |
| no-unsafe-member-access | 33 |
| no-misused-promises | 16 |
| no-unsafe-return | 14 |
| no-unsafe-call | 13 |
| await-thenable | 8 |
| no-base-to-string | 5 |
| restrict-template-expressions | 4 |
| no-redundant-type-constituents | 4 |
| prefer-promise-reject-errors | 3 |
| unbound-method | 2 |
| restrict-plus-operands | 2 |
| only-throw-error | 1 |
| no-unsafe-enum-comparison | 1 |

## Next steps

Fix violations rule-by-rule in separate PRs.