### PR TITLE
style: enable some recommendedTypeChecked rules

### DIFF
--- a/client/src/javascript/actions/AuthActions.ts
+++ b/client/src/javascript/actions/AuthActions.ts
@@ -49,7 +49,7 @@ const AuthActions = {
         Promise.all([
           ClientActions.fetchSettings(),
           SettingActions.fetchSettings(),
-          FloodActions.restartActivityStream(),
+          Promise.resolve(FloodActions.restartActivityStream()),
         ]),
       ),
 

--- a/client/src/javascript/components/general/ContextMenuMountPoint.tsx
+++ b/client/src/javascript/components/general/ContextMenuMountPoint.tsx
@@ -43,7 +43,7 @@ const ContextMenuMountPoint: FC<ContextMenuMountPointProps> = observer(({id}: Co
         switch (item.type) {
           case 'action':
             menuItemClasses = classnames('menu__item', {
-              'is-selectable': item.clickHandler,
+              'is-selectable': true, // action type always has clickHandler
             });
             menuItemContent = (
               <span>

--- a/client/src/javascript/components/sidebar/LocationFilters.tsx
+++ b/client/src/javascript/components/sidebar/LocationFilters.tsx
@@ -21,7 +21,7 @@ const buildLocationFilterTree = (location: LocationTreeNode): ReactNode => {
 
   return (
     <SidebarFilter
-      handleClick={(filter: string | '', event: KeyboardEvent | MouseEvent | TouchEvent) =>
+      handleClick={(filter: string, event: KeyboardEvent | MouseEvent | TouchEvent) =>
         TorrentFilterStore.setLocationFilters(filter, event)
       }
       count={location.containedCount}

--- a/client/src/javascript/components/sidebar/TransferData.tsx
+++ b/client/src/javascript/components/sidebar/TransferData.tsx
@@ -22,6 +22,7 @@ const TransferData: FC = observer(() => {
         }
       }}
     >
+      {/* eslint-disable-next-line @typescript-eslint/unbound-method -- react-measure render props */}
       {({measureRef}) => (
         <div ref={measureRef} className="client-stats__wrapper sidebar__item">
           <div

--- a/client/src/javascript/stores/TorrentFilterStore.ts
+++ b/client/src/javascript/stores/TorrentFilterStore.ts
@@ -60,7 +60,7 @@ class TorrentFilterStore {
     this.filterTrigger = !this.filterTrigger;
   }
 
-  setLocationFilters(filter: string | '', event: KeyboardEvent | MouseEvent | TouchEvent) {
+  setLocationFilters(filter: string, event: KeyboardEvent | MouseEvent | TouchEvent) {
     // keys: [] to disable shift-clicking as it doesn't make sense in a tree
     this.computeFilters([], this.locationFilter, filter, event);
     this.filterTrigger = !this.filterTrigger;
@@ -93,7 +93,7 @@ class TorrentFilterStore {
     this.filterTrigger = !this.filterTrigger;
   }
 
-  private computeFilters<T extends TorrentStatus | string>(
+  private computeFilters<T extends string>(
     keys: readonly T[],
     currentFilters: Array<T>,
     newFilter: T,

--- a/client/src/javascript/ui/icons/CountryFlag.tsx
+++ b/client/src/javascript/ui/icons/CountryFlag.tsx
@@ -33,6 +33,7 @@ const getFlag = (countryCode?: string): string | null => {
     return flag;
   };
 
+  // eslint-disable-next-line @typescript-eslint/only-throw-error -- React Suspense pattern: throw promise
   throw loadFlag();
 };
 

--- a/client/src/javascript/util/processFiles.ts
+++ b/client/src/javascript/util/processFiles.ts
@@ -10,7 +10,7 @@ const readFile = (file: File): Promise<ProcessedFiles[number]> =>
         reject(new Error(`Unable to read file: ${file.name}`));
       }
     };
-    reader.onerror = () => reject(reader.error);
+    reader.onerror = () => reject(new Error('File read failed', {cause: reader.error}));
     reader.readAsDataURL(file);
   });
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -208,6 +208,16 @@ export default [
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-base-to-string': 'off',
+      '@typescript-eslint/restrict-template-expressions': 'off',
+    },
+  },
+
+  // Storybook files
+  {
+    files: ['**/*.stories.ts', '**/*.stories.tsx'],
+    rules: {
+      '@typescript-eslint/no-base-to-string': 'off',
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,13 +34,13 @@ export default [
     files: ['**/*.ts', '**/*.tsx'],
   })),
 
-  // TypeScript type-checked rules for .ts/.tsx files
-  {
-    files: ['**/*.ts', '**/*.tsx'],
-    rules: {
-      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-    },
-  },
+  // TypeScript type-checked rules for .ts/.tsx files - all recommendedTypeChecked rules
+  ...typescriptEslint.configs.recommendedTypeChecked
+    .filter((config) => config.rules)
+    .map((config) => ({
+      ...config,
+      files: ['**/*.ts', '**/*.tsx'],
+    })),
 
   // Prettier config (disables conflicting rules)
   prettierConfig,
@@ -82,6 +82,16 @@ export default [
       '@typescript-eslint/no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
       '@typescript-eslint/no-explicit-any': 'off', // Allow any for now
       '@typescript-eslint/no-non-null-assertion': 'off', // Allow ! operator
+      '@typescript-eslint/require-await': 'off', // Too many false positives with Fastify plugins
+
+      // TODO: Enable these rules and fix violations
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-misused-promises': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
     },
   },
 

--- a/server/bin/enforce-prerequisites.ts
+++ b/server/bin/enforce-prerequisites.ts
@@ -1,4 +1,4 @@
-const enforcePrerequisites = async (): Promise<void> => {
+const enforcePrerequisites = (): void => {
   // Ensures that WebAssembly support is present
   if (typeof WebAssembly === 'undefined') {
     throw new Error('WebAssembly is not supported in this environment!');

--- a/server/bin/migrations/run.ts
+++ b/server/bin/migrations/run.ts
@@ -5,7 +5,7 @@ import HistoryEra from './02-HistoryEra';
 const migrations = [UserInDatabase2, UserInDatabase3, HistoryEra];
 
 const migrate = async () => {
-  for await (const migrate of migrations) {
+  for (const migrate of migrations) {
     await migrate();
   }
 };

--- a/server/bin/start.ts
+++ b/server/bin/start.ts
@@ -25,7 +25,7 @@ if (process.env.NODE_ENV == 'production') {
 }
 
 const main = async () => {
-  await enforcePrerequisites();
+  enforcePrerequisites();
   await migrateData();
   await startWebServer();
 };

--- a/server/middleware/authenticate.ts
+++ b/server/middleware/authenticate.ts
@@ -31,7 +31,7 @@ export const getRequiredAuthContext = (request: FastifyRequest): AuthedContext =
 };
 
 /** Verify a raw JWT string and return its decoded payload, or undefined on failure. */
-const decodeToken = (token: string): unknown | undefined => {
+const decodeToken = (token: string): unknown => {
   try {
     return jwt.verify(token, config.secret);
   } catch {

--- a/server/models/Users.ts
+++ b/server/models/Users.ts
@@ -126,7 +126,7 @@ class Users {
     return this.db.findOneAsync<UserInDatabase>({username}).then(async ({_id}) => {
       await destroyUserServices(_id, true);
 
-      await this.db.remove({username}, {});
+      await this.db.removeAsync({username}, {});
       await fs.promises.rm(path.join(config.dbPath, _id), {recursive: true}).catch(() => undefined);
 
       return _id;

--- a/server/services/Deluge/clientGatewayService.ts
+++ b/server/services/Deluge/clientGatewayService.ts
@@ -45,7 +45,7 @@ class DelugeClientGatewayService extends BaseClientGatewayService implements Cli
     this.clientRequestManager = clientRequestManager;
   }
 
-  static async create(user: UserInDatabase): Promise<DelugeClientGatewayService> {
+  static create(user: UserInDatabase): DelugeClientGatewayService {
     const clientRequestManager = new ClientRequestManager(user.client as DelugeConnectionSettings);
     return new DelugeClientGatewayService(user, clientRequestManager);
   }
@@ -73,7 +73,7 @@ class DelugeClientGatewayService extends BaseClientGatewayService implements Cli
 
     if (isCompleted) {
       // Deluge does not provide function to add completed torrents
-      for await (const hash of result) {
+      for (const hash of result) {
         await this.checkTorrents({hashes: [hash]});
       }
     }

--- a/server/services/Deluge/clientRequestManager.ts
+++ b/server/services/Deluge/clientRequestManager.ts
@@ -50,7 +50,7 @@ class ClientRequestManager {
         const [, reject] = this.requestQueue[request_id as number] ?? [];
 
         delete this.requestQueue[request_id as number];
-        reject?.(new Error(`${exception_type}: ${exception_msg}`));
+        reject?.(new Error(`${JSON.stringify(exception_type)}: ${JSON.stringify(exception_msg)}`));
 
         return;
       }
@@ -116,7 +116,7 @@ class ClientRequestManager {
 
       const handleError = (e: Error) => {
         tlsSocket.destroy();
-        this.rpcWithAuth = this.rpc = Promise.reject();
+        this.rpcWithAuth = this.rpc = Promise.reject(new Error('Connection failed', {cause: e}));
         reject(e);
       };
 

--- a/server/services/Deluge/util/rencode.ts
+++ b/server/services/Deluge/util/rencode.ts
@@ -368,7 +368,7 @@ function decodeKeyValuePair(d: RencodableObject, data: Buff, decodeUTF8: boolean
   const key = decode(data, decodeUTF8);
   const value = decode(data, decodeUTF8);
   if (!(typeof key == 'string' || typeof key == 'number'))
-    throw TypeError('Received invalid value for dictionary key: ' + key);
+    throw TypeError(`Received invalid value for dictionary key: ${JSON.stringify(key)}`);
   d[key] = value;
 }
 

--- a/server/services/Transmission/clientGatewayService.ts
+++ b/server/services/Transmission/clientGatewayService.ts
@@ -45,7 +45,7 @@ class TransmissionClientGatewayService extends BaseClientGatewayService implemen
     this.clientRequestManager = clientRequestManager;
   }
 
-  static async create(user: UserInDatabase): Promise<TransmissionClientGatewayService> {
+  static create(user: UserInDatabase): TransmissionClientGatewayService {
     const clientRequestManager = new ClientRequestManager(user.client as TransmissionConnectionSettings);
     return new TransmissionClientGatewayService(user, clientRequestManager);
   }

--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -61,7 +61,7 @@ class QBittorrentClientGatewayService extends BaseClientGatewayService implement
     this.clientRequestManager = clientRequestManager;
   }
 
-  static async create(user: UserInDatabase): Promise<QBittorrentClientGatewayService> {
+  static create(user: UserInDatabase): QBittorrentClientGatewayService {
     const clientRequestManager = new ClientRequestManager(user.client as QBittorrentConnectionSettings);
     return new QBittorrentClientGatewayService(user, clientRequestManager);
   }
@@ -408,7 +408,7 @@ class QBittorrentClientGatewayService extends BaseClientGatewayService implement
         // qBittorrent can not handle requests in a highly concurrent way.
         const TRACKER_MESSAGE_TTL = 60 * 60 * 1000; // 1 hour
 
-        for await (const {hash} of infos) {
+        for (const {hash} of infos) {
           if (this.cachedProperties[hash] == null) {
             await this.fetchProperties(hash, true);
           } else if (Date.now() - this.cachedProperties[hash].trackerMessageFetchedAt > TRACKER_MESSAGE_TTL) {

--- a/server/services/rTorrent/clientGatewayService.ts
+++ b/server/services/rTorrent/clientGatewayService.ts
@@ -25,6 +25,7 @@ import type {
 import type {ClientSettings} from '@shared/types/ClientSettings';
 import type {TorrentList, TorrentListSummary, TorrentProperties} from '@shared/types/Torrent';
 import type {TorrentContent} from '@shared/types/TorrentContent';
+import {TorrentContentPriority} from '@shared/types/TorrentContent';
 import type {TorrentPeer} from '@shared/types/TorrentPeer';
 import type {TorrentTracker} from '@shared/types/TorrentTracker';
 import type {TransferSummary} from '@shared/types/TransferData';
@@ -399,7 +400,10 @@ class RTorrentClientGatewayService extends BaseClientGatewayService implements C
     let selectedSize = cached.selectedSize;
     try {
       const contents = await this.getTorrentContents(hash);
-      selectedSize = contents.reduce((sum, file) => (file.priority > 0 ? sum + file.sizeBytes : sum), 0);
+      selectedSize = contents.reduce(
+        (sum, file) => (file.priority !== TorrentContentPriority.DO_NOT_DOWNLOAD ? sum + file.sizeBytes : sum),
+        0,
+      );
     } catch {
       return cached.selectedSize;
     }
@@ -622,12 +626,12 @@ class RTorrentClientGatewayService extends BaseClientGatewayService implements C
       .then(this.processClientRequestSuccess, this.processRTorrentRequestError);
 
     // Delete contents of torrents
-    for await (const contentPath of contentPaths) {
+    for (const contentPath of contentPaths) {
       await fs.promises.unlink(contentPath).catch(() => undefined);
     }
 
     // Try to remove empty directories
-    for await (const directoryPath of directoryPaths) {
+    for (const directoryPath of directoryPaths) {
       await fs.promises.rmdir(directoryPath).catch(() => undefined);
     }
   }
@@ -952,7 +956,7 @@ class RTorrentClientGatewayService extends BaseClientGatewayService implements C
 
   async setClientSettings(settings: SetClientSettingsOptions): Promise<void> {
     const configs = clientSettingMethodCallConfigs;
-    const {methodList} = await this.availableMethodCalls;
+    const {methodList} = this.availableMethodCalls;
     const methodCalls = Object.keys(settings).reduce((accumulator: MultiMethodCalls, key) => {
       const property = key as keyof SetClientSettingsOptions;
       let methodName = '';
@@ -998,7 +1002,7 @@ class RTorrentClientGatewayService extends BaseClientGatewayService implements C
 
       accumulator.push({
         methodName,
-        params: ['', `${param}`],
+        params: ['', Array.isArray(param) ? param.join(',') : String(param)],
       });
 
       return accumulator;

--- a/server/services/rTorrent/util/XMLRPCDeserializer.ts
+++ b/server/services/rTorrent/util/XMLRPCDeserializer.ts
@@ -42,7 +42,7 @@ const onError = (err: Error) => {
 
 const closeTag = (elementName: string) => {
   let stackMark;
-  const tagValue = tmpData.join('');
+  const tagValue = (tmpData as string[]).join('');
   switch (elementName) {
     case 'boolean':
       dataStack.push(tagValue === '1');

--- a/server/services/rTorrent/util/XMLRPCSerializer.ts
+++ b/server/services/rTorrent/util/XMLRPCSerializer.ts
@@ -42,7 +42,7 @@ const value = (value: XMLRPCValue): string => {
     value = members(value as {[key: string]: XMLRPCValue});
   }
 
-  return `<value><${type}>${value}</${type}></value>`;
+  return `<value><${type}>${value as string}</${type}></value>`;
 };
 
 const data = (values: XMLRPCValue[]) => {

--- a/server/util/authUtil.ts
+++ b/server/util/authUtil.ts
@@ -63,7 +63,7 @@ export const verifyToken = async (token: string): Promise<Record<string, unknown
   new Promise((resolve, reject) => {
     jwt.verify(token, config.secret, (err, decoded) => {
       if (err !== null || decoded == null) {
-        reject(err);
+        reject(err ?? new Error('Token verification failed'));
         return;
       }
 


### PR DESCRIPTION
## Summary

Fix ESLint violations from recommendedTypeChecked rules and disable remaining rules that need more work.

## Fixed Rules (auto-fixable and small manual fixes)

- `no-unnecessary-type-assertion`: removed redundant type assertions
- `no-unsafe-enum-comparison`: use enum members for comparison
- `only-throw-error`: suppress false positive for React Suspense
- `unbound-method`: suppress false positive for react-measure render props
- `restrict-plus-operands`: use template literals
- `prefer-promise-reject-errors`: wrap rejections with Error objects
- `no-redundant-type-constituents`: remove redundant types
- `restrict-template-expressions`: use JSON.stringify/String for complex types
- `no-base-to-string`: cast tmpData to string[]
- `await-thenable`: fix incorrect usage of for await...of and await non-Promise
- `require-await`: disabled due to Fastify plugin requirements

## Disabled Rules (TODO: fix later)

- `no-floating-promises`
- `no-unsafe-assignment`
- `no-unsafe-argument`
- `no-unsafe-member-access`
- `no-misused-promises`
- `no-unsafe-return`
- `no-unsafe-call`