### PR TITLE
fix(scss): correct font URLs path in `_font-families.scss`

### DIFF
--- a/client/src/sass/base/_font-families.scss
+++ b/client/src/sass/base/_font-families.scss
@@ -4,7 +4,7 @@
   font-style: normal;
   src:
     local('Roboto-regular'),
-    url('../fonts/Roboto-regular/Roboto-regular.woff2') format('woff2');
+    url('../../fonts/Roboto-regular/Roboto-regular.woff2') format('woff2');
 }
 
 @font-face {
@@ -13,7 +13,7 @@
   font-style: normal;
   src:
     local('Roboto-500'),
-    url('../fonts/Roboto-500/Roboto-500.woff2') format('woff2');
+    url('../../fonts/Roboto-500/Roboto-500.woff2') format('woff2');
 }
 
 @font-face {
@@ -22,7 +22,7 @@
   font-style: normal;
   src:
     local('Roboto-700'),
-    url('../fonts/Roboto-700/Roboto-700.woff2') format('woff2');
+    url('../../fonts/Roboto-700/Roboto-700.woff2') format('woff2');
 }
 
 @font-face {
@@ -31,7 +31,7 @@
   font-style: italic;
   src:
     local('Roboto-italic'),
-    url('../fonts/Roboto-italic/Roboto-italic.woff2') format('woff2');
+    url('../../fonts/Roboto-italic/Roboto-italic.woff2') format('woff2');
 }
 
 @font-face {
@@ -40,5 +40,5 @@
   font-style: italic;
   src:
     local('Roboto Bold Italic'),
-    url('../fonts/Roboto-700italic/Roboto-700italic.woff2') format('woff2');
+    url('../../fonts/Roboto-700italic/Roboto-700italic.woff2') format('woff2');
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
