### PR TITLE
fix(client): handle dateActive "currently active" sentinel in list column

### DIFF
--- a/client/src/javascript/components/torrent-list/TorrentListCell.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentListCell.tsx
@@ -68,6 +68,11 @@ const DateCell: FC<{date: number}> = observer(({date}: {date: number}) => {
     return null;
   }
 
+  // -1 is the client gateways' "currently active" sentinel for dateActive
+  if (date === -1) {
+    return <span>{i18n._('torrents.details.general.date.active.now')}</span>;
+  }
+
   return <span>{formatDate(i18n.locale, new Date(date * 1000))}</span>;
 });
 

--- a/client/src/javascript/util/sortTorrents.ts
+++ b/client/src/javascript/util/sortTorrents.ts
@@ -33,6 +33,17 @@ function sortTorrents(
         },
       } as SortRule);
       break;
+    case 'dateActive':
+      sortRules.push({
+        [sortBy.direction]: (p: TorrentProperties) => {
+          // -1 means currently active, i.e. more recent than any timestamp
+          if (p.dateActive === -1) {
+            return Infinity;
+          }
+          return p.dateActive;
+        },
+      } as SortRule);
+      break;
     case 'tags':
       sortRules.push({
         [sortBy.direction]: (p: TorrentProperties) => p[property].join(',').toLowerCase(),


### PR DESCRIPTION
Fixes #1323.

Client gateways set `dateActive: -1` while a torrent is transferring. The Last Activity column rendered that literally as Dec 31, 1969 and sorted it as older than any real timestamp.

- `DateCell`: render `-1` as "Now", reusing `torrents.details.general.date.active.now` (already translated; the details modal uses the same string for this case)
- `sortTorrents`: map `-1` to `Infinity` so active torrents sort as most recent, mirroring the existing `eta` sentinel handling

Verified on a live qBittorrent-backed instance (4.15.0 + this patch): actively uploading torrents show "Now" and sort to the most-recent end in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)