### PR TITLE
fix: adjust after react-dom v8 upgrade

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,7 +8,7 @@ import {i18n} from '@lingui/core';
 import {I18nProvider} from '@lingui/react';
 import type {Preview} from '@storybook/react';
 import React, {useEffect} from 'react';
-import {BrowserRouter} from 'react-router-dom';
+import {BrowserRouter} from 'react-router';
 
 // Import language files with Lingui loader
 import {messages as enMessages} from '../client/src/javascript/i18n/strings/en.json?lingui';

--- a/client/src/javascript/app.tsx
+++ b/client/src/javascript/app.tsx
@@ -1,8 +1,7 @@
-import {BrowserRouter} from 'react-router-dom';
+import {BrowserRouter, Route, Routes} from 'react-router';
 import {createRoot} from 'react-dom/client';
 import {FC, lazy, Suspense, useEffect} from 'react';
 import {observer} from 'mobx-react-lite';
-import {Route, Routes} from 'react-router';
 import {useMedia} from 'react-use';
 
 import AppWrapper from './components/AppWrapper';

--- a/client/src/javascript/components/AppWrapper.tsx
+++ b/client/src/javascript/components/AppWrapper.tsx
@@ -2,8 +2,7 @@ import classnames from 'classnames';
 import {FC, ReactNode} from 'react';
 import {observer} from 'mobx-react-lite';
 import {useEffectOnce} from 'react-use';
-import {useNavigate} from 'react-router';
-import {useSearchParams} from 'react-router-dom';
+import {useNavigate, useSearchParams} from 'react-router';
 import {css} from '@client/styled-system/css';
 
 import AuthActions from '@client/actions/AuthActions';

--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "react-markdown": "10.1.0",
     "react-measure": "2.5.2",
     "react-router": "8.2.0",
-    "react-router-dom": "7.18.1",
     "react-transition-state": "2.4.0",
     "react-use": "17.6.1",
     "react-window": "2.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,9 +350,6 @@ importers:
       react-router:
         specifier: 8.2.0
         version: 8.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom:
-        specifier: 7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-transition-state:
         specifier: 2.4.0
         version: 2.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6700,23 +6697,6 @@ packages:
     peerDependencies:
       react: '>0.13.0'
       react-dom: '>0.13.0'
-
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
 
   react-router@8.2.0:
     resolution: {integrity: sha512-uP1LgGNHyilL1u+ZkecQk74DJOKOb6q4NLNYLRJcD/fjoogftNb5/Rj/07o/QBFsY/5MbAKPm1peTCQuVPv9cQ==}
@@ -14828,20 +14808,6 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       resize-observer-polyfill: 1.5.1
-
-  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
-  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.7
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.7(react@19.2.7)
 
   react-router@8.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

DISCLAIMER: I don't know the first thing about React. I asked GPT 5.6 Terra (high) to debug it. It first wanted to remove `react-router` and rely on `react-router-dom`. I checked the DOM package and the reverse seems to be correct direction. 


Current master build (Docker Hub) fails with:
```
Uncaught Error: useNavigate() may be used only in the context of a
<Router> component.
```

`react-dom-router` has the following note in the README:
```
This package simply re-exports everything from react-router to smooth
the upgrade path for v6 applications. Once upgraded you can change all
of your imports and remove it from your dependencies
```

Importing directly from `react-router` seems fixes it.
<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
