### PR TITLE
fix(client): restore overlayscrollbars custom scrollbar on torrent list

### DIFF
--- a/client/src/javascript/components/general/ListViewport.tsx
+++ b/client/src/javascript/components/general/ListViewport.tsx
@@ -1,4 +1,5 @@
 import {forwardRef, useCallback, useEffect, useRef} from 'react';
+import {reaction} from 'mobx';
 import {List} from 'react-window';
 import {observer} from 'mobx-react-lite';
 import {OverlayScrollbars} from 'overlayscrollbars';
@@ -64,17 +65,21 @@ const ListViewport = forwardRef<ListImperativeAPI, ListViewportProps>((props: Li
   }, []);
 
   // Update scrollbar theme when dark/light mode changes
-  // ConfigStore.isPreferDark is a MobX computed value tracked by observer()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    osInstanceRef.current?.options({
-      scrollbars: {
-        autoHide: 'leave',
-        clickScroll: true,
-        theme: `os-theme-${ConfigStore.isPreferDark ? 'light' : 'dark'}`,
+    const dispose = reaction(
+      () => ConfigStore.isPreferDark,
+      (isDark) => {
+        osInstanceRef.current?.options({
+          scrollbars: {
+            autoHide: 'leave',
+            clickScroll: true,
+            theme: `os-theme-${isDark ? 'light' : 'dark'}`,
+          },
+        });
       },
-    });
-  }, [ConfigStore.isPreferDark]);
+    );
+    return dispose;
+  }, []);
 
   return (
     <div className={className} style={{height: Math.max(rowHeight * 30, 600), width: '100%'}}>

--- a/client/src/javascript/components/general/ListViewport.tsx
+++ b/client/src/javascript/components/general/ListViewport.tsx
@@ -1,6 +1,9 @@
-import {forwardRef} from 'react';
+import {forwardRef, useCallback, useEffect, useRef} from 'react';
 import {List} from 'react-window';
 import {observer} from 'mobx-react-lite';
+import {OverlayScrollbars} from 'overlayscrollbars';
+
+import ConfigStore from '@client/stores/ConfigStore';
 
 import type {ListImperativeAPI, RowComponentProps} from 'react-window';
 
@@ -14,6 +17,64 @@ interface ListViewportProps {
 
 const ListViewport = forwardRef<ListImperativeAPI, ListViewportProps>((props: ListViewportProps, ref) => {
   const {className, rowCount, rowComponent, rowHeight, listRef} = props;
+  const innerListRef = useRef<ListImperativeAPI | null>(null);
+  const osInstanceRef = useRef<ReturnType<typeof OverlayScrollbars> | null>(null);
+
+  const mergedRef = useCallback(
+    (instance: ListImperativeAPI | null) => {
+      innerListRef.current = instance;
+
+      // Forward to listRef prop
+      if (typeof listRef === 'function') {
+        listRef(instance);
+      } else if (listRef != null) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        (listRef as React.MutableRefObject<ListImperativeAPI | null>).current = instance;
+      }
+
+      // Forward to forwarded ref
+      if (typeof ref === 'function') {
+        ref(instance);
+      } else if (ref != null) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        (ref as React.MutableRefObject<ListImperativeAPI | null>).current = instance;
+      }
+    },
+    [listRef, ref],
+  );
+
+  // Initialize OverlayScrollbars on the List's outer DOM element after mount
+  useEffect(() => {
+    const element = innerListRef.current?.element;
+    if (!element) return;
+
+    const osInstance = OverlayScrollbars(element, {
+      scrollbars: {
+        autoHide: 'leave',
+        clickScroll: true,
+        theme: `os-theme-${ConfigStore.isPreferDark ? 'light' : 'dark'}`,
+      },
+    });
+    osInstanceRef.current = osInstance;
+
+    return () => {
+      osInstance.destroy();
+      osInstanceRef.current = null;
+    };
+  }, []);
+
+  // Update scrollbar theme when dark/light mode changes
+  // ConfigStore.isPreferDark is a MobX computed value tracked by observer()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    osInstanceRef.current?.options({
+      scrollbars: {
+        autoHide: 'leave',
+        clickScroll: true,
+        theme: `os-theme-${ConfigStore.isPreferDark ? 'light' : 'dark'}`,
+      },
+    });
+  }, [ConfigStore.isPreferDark]);
 
   return (
     <div className={className} style={{height: Math.max(rowHeight * 30, 600), width: '100%'}}>
@@ -21,7 +82,7 @@ const ListViewport = forwardRef<ListImperativeAPI, ListViewportProps>((props: Li
         defaultHeight={Math.max(rowHeight * 30, 600)}
         rowCount={rowCount}
         rowHeight={rowHeight}
-        listRef={listRef ?? ref}
+        listRef={mergedRef}
         overscanCount={30}
         rowComponent={rowComponent}
         rowProps={{}}


### PR DESCRIPTION
The react-window v1 → v2 upgrade removed the outerElementType prop support, which previously allowed wrapping the virtual list with an OverlayScrollbarsComponent for custom, themed scrollbars (#1260).

Replace the OverlayScrollbarsComponent approach with direct initialization of the OverlayScrollbars core library on react-window List's DOM element after mount, via the listRef.element getter.

Theme changes (dark/light) are handled by updating the overlayscrollbars instance options without destroying and recreating.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [ ] Bug fix (non-breaking change which fixes an issue - semver PATCH)
