### PR TITLE
fix(client): initialize overlayscrollbars after list ref resolves

### DIFF
--- a/client/src/javascript/components/general/ListViewport.tsx
+++ b/client/src/javascript/components/general/ListViewport.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, useCallback, useEffect, useRef} from 'react';
+import {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
 import {reaction} from 'mobx';
 import {List} from 'react-window';
 import {observer} from 'mobx-react-lite';
@@ -18,12 +18,12 @@ interface ListViewportProps {
 
 const ListViewport = forwardRef<ListImperativeAPI, ListViewportProps>((props: ListViewportProps, ref) => {
   const {className, rowCount, rowComponent, rowHeight, listRef} = props;
-  const innerListRef = useRef<ListImperativeAPI | null>(null);
-  const osInstanceRef = useRef<ReturnType<typeof OverlayScrollbars> | null>(null);
+  const hostElementRef = useRef<HTMLDivElement>(null);
+  const [listElement, setListElement] = useState<HTMLDivElement | null>(null);
 
   const mergedRef = useCallback(
     (instance: ListImperativeAPI | null) => {
-      innerListRef.current = instance;
+      setListElement(instance?.element ?? null);
 
       // Forward to listRef prop
       if (typeof listRef === 'function') {
@@ -44,45 +44,46 @@ const ListViewport = forwardRef<ListImperativeAPI, ListViewportProps>((props: Li
     [listRef, ref],
   );
 
-  // Initialize OverlayScrollbars on the List's outer DOM element after mount
+  // react-window exposes its DOM element after the initial ref callback.
   useEffect(() => {
-    const element = innerListRef.current?.element;
-    if (!element) return;
+    const hostElement = hostElementRef.current;
+    if (hostElement == null || listElement == null) return;
 
-    const osInstance = OverlayScrollbars(element, {
-      scrollbars: {
-        autoHide: 'leave',
-        clickScroll: true,
-        theme: `os-theme-${ConfigStore.isPreferDark ? 'light' : 'dark'}`,
+    const osInstance = OverlayScrollbars(
+      {
+        target: hostElement,
+        elements: {
+          viewport: listElement,
+        },
       },
-    });
-    osInstanceRef.current = osInstance;
+      {
+        scrollbars: {
+          autoHide: 'leave',
+          clickScroll: true,
+          theme: `os-theme-${ConfigStore.isPreferDark ? 'light' : 'dark'}`,
+        },
+      },
+    );
 
-    return () => {
-      osInstance.destroy();
-      osInstanceRef.current = null;
-    };
-  }, []);
-
-  // Update scrollbar theme when dark/light mode changes
-  useEffect(() => {
     const dispose = reaction(
       () => ConfigStore.isPreferDark,
       (isDark) => {
-        osInstanceRef.current?.options({
+        osInstance.options({
           scrollbars: {
-            autoHide: 'leave',
-            clickScroll: true,
             theme: `os-theme-${isDark ? 'light' : 'dark'}`,
           },
         });
       },
     );
-    return dispose;
-  }, []);
+
+    return () => {
+      dispose();
+      osInstance.destroy();
+    };
+  }, [listElement]);
 
   return (
-    <div className={className} style={{height: Math.max(rowHeight * 30, 600), width: '100%'}}>
+    <div className={className} ref={hostElementRef} style={{height: Math.max(rowHeight * 30, 600), width: '100%'}}>
       <List
         defaultHeight={Math.max(rowHeight * 30, 600)}
         rowCount={rowCount}


### PR DESCRIPTION
## Summary

- initialize OverlayScrollbars only after react-window exposes its list DOM element
- use the existing wrapper as the host and the react-window element as the viewport
- bind the theme reaction to the OverlayScrollbars instance lifecycle

## Root cause

Follow-up to #1328. The mount-only effect could observe a null listRef.element and return without retrying, so OverlayScrollbars was never initialized and the torrent list kept its native scrollbar.

## Testing

- pnpm run check-types
- pnpm run lint
- pnpm run build
- manually verified the scrollbar in light and dark themes