### PR TITLE
build: use replace rolldown with vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
     "react-use": "17.6.1",
     "react-window": "2.3.0",
     "ress": "5.0.2",
-    "rolldown": "1.2.0",
     "sanitize-filename": "1.6.4",
     "sass": "1.101.6",
     "saxen": "11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,9 +362,6 @@ importers:
       ress:
         specifier: 5.0.2
         version: 5.0.2
-      rolldown:
-        specifier: 1.2.0
-        version: 1.2.0
       sanitize-filename:
         specifier: 1.6.4
         version: 1.6.4
@@ -9693,7 +9690,8 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
-  '@oxc-project/types@0.140.0': {}
+  '@oxc-project/types@0.140.0':
+    optional: true
 
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     optional: true
@@ -15133,6 +15131,7 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.2.0
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
+    optional: true
 
   rollup@4.62.0:
     dependencies:

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -2,12 +2,9 @@ import path from 'node:path';
 
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import {build as rolldownBuild} from 'rolldown';
 import {build as viteBuild} from 'vite';
 
 import {buildPaths} from '../shared/config/buildPaths.mjs';
-
-const paths = buildPaths;
 
 process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
@@ -102,26 +99,16 @@ const build = async () => {
     mode: 'production',
   });
 
-  const embeddedAssets = collectEmbeddedAssets(paths.appBuild);
+  const embeddedAssets = collectEmbeddedAssets(buildPaths.appBuild);
 
   console.log('building server (embedding ui assets)...');
 
-  await rolldownBuild({
-    input: [path.resolve(buildPaths.appSrc, 'server/bin/start.ts')],
-    output: {
-      file: path.resolve(buildPaths.appSrc, 'dist/index.js'),
-      codeSplitting: false,
-      format: 'cjs',
-      sourcemap: 'inline',
+  await viteBuild({
+    configFile: path.resolve('vite.server.config.ts'),
+    mode: 'production',
+    define: {
+      __FLOOD_EMBEDDED_ASSETS__: JSON.stringify(embeddedAssets),
     },
-    transform: {
-      define: {
-        __FLOOD_EMBEDDED_ASSETS__: JSON.stringify(embeddedAssets),
-      },
-      target: 'node12',
-    },
-    platform: 'node',
-    external: ['geoip-country'],
   });
 
   console.log('Client build complete.');

--- a/vite.server.config.ts
+++ b/vite.server.config.ts
@@ -1,6 +1,36 @@
+import path from 'node:path';
+
 import {defineConfig} from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-export default defineConfig({
-  plugins: [tsconfigPaths()],
+import {buildPaths} from './shared/config/buildPaths.mjs';
+
+export default defineConfig(({command}) => {
+  if (command === 'serve') {
+    return {
+      plugins: [tsconfigPaths()],
+    };
+  }
+
+  return {
+    ssr: {
+      noExternal: true,
+    },
+    build: {
+      emptyOutDir: false,
+      minify: false,
+      outDir: path.resolve(buildPaths.appSrc, 'dist'),
+      rolldownOptions: {
+        external: ['geoip-country'],
+        output: {
+          codeSplitting: false,
+          entryFileNames: 'index.js',
+          format: 'cjs',
+        },
+      },
+      sourcemap: 'inline',
+      ssr: path.resolve(buildPaths.appSrc, 'server/bin/start.ts'),
+      target: 'node12',
+    },
+  };
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Continuation of #1325. 

Most crucial detail is that I needed to add:
```js
    ssr: {
      noExternal: true,
    },
```
in order for vite to bundle all the modules. w/o it the bundled `index.js` is 21M instead of expected 35M.

FTR I see that rolldown did prefer `const` and current output prefers `var`. I looked around and can't tell exactly why this happens. 

<!--- Describe your changes in detail -->

## Related Issue

<!--- Optional -->

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
