### PR TITLE
build: replace vite-tsconfig-paths plugin with native Vite support

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,6 @@
     "typescript-eslint": "8.65.0",
     "vite": "8.1.5",
     "vite-node": "6.0.0",
-    "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.10",
     "yargs": "17.7.3",
     "zod": "4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,9 +404,6 @@ importers:
       vite-node:
         specifier: 6.0.0
         version: 6.0.0(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.6)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
-      vite-tsconfig-paths:
-        specifier: 6.1.1
-        version: 6.1.1(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.6)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.6)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0))
@@ -7469,17 +7466,6 @@ packages:
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -7663,11 +7649,6 @@ packages:
     resolution: {integrity: sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -15802,10 +15783,6 @@ snapshots:
 
   ts-pattern@5.9.0: {}
 
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -16065,16 +16042,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite-tsconfig-paths@6.1.1(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.6)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.6)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.6)(terser@5.46.2)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:

--- a/vite.server.config.ts
+++ b/vite.server.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  resolve: {
+    tsconfigPaths: true,
+  },
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,9 +1,6 @@
 import {defineConfig, defineProject, type ViteUserConfig} from 'vitest/config';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 type VitestPlugin = NonNullable<ViteUserConfig['plugins']>[number];
-
-const tsconfigPathsPlugin = tsconfigPaths() as VitestPlugin;
 
 const baseTestConfig = {
   environment: 'node' as const,
@@ -20,13 +17,17 @@ const baseTestConfig = {
 };
 
 export default defineConfig({
-  plugins: [tsconfigPathsPlugin],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     globals: true,
     environment: 'node',
     projects: [
       defineProject({
-        plugins: [tsconfigPathsPlugin],
+        resolve: {
+          tsconfigPaths: true,
+        },
         test: {
           ...baseTestConfig,
           name: 'auth',
@@ -35,7 +36,9 @@ export default defineConfig({
         },
       }),
       defineProject({
-        plugins: [tsconfigPathsPlugin],
+        resolve: {
+          tsconfigPaths: true,
+        },
         test: {
           ...baseTestConfig,
           name: 'qbittorrent',
@@ -45,7 +48,9 @@ export default defineConfig({
         },
       }),
       defineProject({
-        plugins: [tsconfigPathsPlugin],
+        resolve: {
+          tsconfigPaths: true,
+        },
         test: {
           ...baseTestConfig,
           name: 'rtorrent',
@@ -55,7 +60,9 @@ export default defineConfig({
         },
       }),
       defineProject({
-        plugins: [tsconfigPathsPlugin],
+        resolve: {
+          tsconfigPaths: true,
+        },
         test: {
           ...baseTestConfig,
           name: 'transmission',


### PR DESCRIPTION
Vite 8 now supports tsconfig paths resolution natively via `resolve.tsconfigPaths` option.

This PR:
- Removes the `vite-tsconfig-paths` dependency
- Replaces plugin usage with `resolve.tsconfigPaths: true` in `vite.server.config.ts` and `vitest.config.mts`

This eliminates the deprecation warning shown during build.