### PR TITLE
build: update Node.js target to v22

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -118,7 +118,7 @@ const build = async () => {
       define: {
         __FLOOD_EMBEDDED_ASSETS__: JSON.stringify(embeddedAssets),
       },
-      target: 'node12',
+      target: 'node22',
     },
     platform: 'node',
     external: ['geoip-country'],


### PR DESCRIPTION
Update the build target from Node.js 12 to Node.js 22 in rolldown configuration.