### PR TITLE
fix: upgrade eslint-plugin-react-hooks to v7 and fix hooks violations

### DIFF
--- a/client/src/javascript/components/general/PriorityMeter.tsx
+++ b/client/src/javascript/components/general/PriorityMeter.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactNode, useState} from 'react';
+import React, {FC, ReactNode, useCallback, useEffect, useState} from 'react';
 import {useLingui} from '@lingui/react';
 import {css} from '@client/styled-system/css';
 
@@ -28,7 +28,7 @@ const PriorityMeter: FC<PriorityMeterProps> = ({
   const {i18n} = useLingui();
   const [priorityLevel, setPriorityLevel] = useState<number>(level);
 
-  const changePriority = () => {
+  const changePriority = useCallback(() => {
     let newLevel = priorityLevel;
 
     if (newLevel >= maxLevel) {
@@ -41,11 +41,13 @@ const PriorityMeter: FC<PriorityMeterProps> = ({
     onChange(id, newLevel);
 
     return newLevel;
-  };
+  }, [id, maxLevel, onChange, priorityLevel]);
 
-  if (changePriorityFuncRef != null) {
-    changePriorityFuncRef.current = changePriority;
-  }
+  useEffect(() => {
+    if (changePriorityFuncRef != null) {
+      changePriorityFuncRef.current = changePriority;
+    }
+  }, [changePriority, changePriorityFuncRef]);
 
   let labelElement: ReactNode;
   if (showLabel) {

--- a/client/src/javascript/components/modals/ModalTabs.tsx
+++ b/client/src/javascript/components/modals/ModalTabs.tsx
@@ -22,9 +22,7 @@ const ModalTabs: FC<ModalTabsProps> = ({activeTabId, tabs = {}, onTabChange}: Mo
   return (
     <ul className="modal__tabs">
       {Object.keys(tabs).map((tabId) => {
-        const currentTab = tabs[tabId];
-
-        currentTab.id = tabId;
+        const currentTab = {...tabs[tabId], id: tabId};
 
         const classes = classnames('modal__tab', {
           'is-active': tabId === activeTabId,

--- a/client/src/javascript/components/modals/settings-modal/lists/TorrentContextMenuActionsList.tsx
+++ b/client/src/javascript/components/modals/settings-modal/lists/TorrentContextMenuActionsList.tsx
@@ -1,4 +1,4 @@
-import {FC, useRef} from 'react';
+import {FC, useState} from 'react';
 
 import SettingStore from '@client/stores/SettingStore';
 import ToggleList from '@client/components/general/ToggleList';
@@ -17,7 +17,9 @@ interface TorrentContextMenuActionsListProps {
 const TorrentContextMenuActionsList: FC<TorrentContextMenuActionsListProps> = ({
   onSettingsChange,
 }: TorrentContextMenuActionsListProps) => {
-  const changedTorrentContextMenuActionsRef = useRef<FloodSettings['torrentContextMenuActions']>(
+  const [changedTorrentContextMenuActions, setChangedTorrentContextMenuActions] = useState<
+    FloodSettings['torrentContextMenuActions']
+  >(() =>
     defaultFloodSettings.torrentContextMenuActions.map(({id, visible: defaultVisible}) => ({
       id,
       visible:
@@ -32,15 +34,13 @@ const TorrentContextMenuActionsList: FC<TorrentContextMenuActionsListProps> = ({
       items={Object.keys(TorrentContextMenuActions).map((action) => ({
         label: TorrentContextMenuActions[action as TorrentContextMenuAction],
         isLocked: action === 'start' || action === 'stop' || action === 'setTaxonomy' || action === 'torrentDetails',
-        defaultChecked: changedTorrentContextMenuActionsRef.current.some(
-          (setting) => setting.id === action && setting.visible,
-        ),
-        onClick: () => {
-          const currentSetting = changedTorrentContextMenuActionsRef.current.find((setting) => setting.id === action);
-          if (currentSetting != null) {
-            currentSetting.visible = !currentSetting.visible;
-          }
-          onSettingsChange({torrentContextMenuActions: changedTorrentContextMenuActionsRef.current});
+        checked: changedTorrentContextMenuActions.some((setting) => setting.id === action && setting.visible),
+        onClick: (visible) => {
+          const nextSettings = changedTorrentContextMenuActions.map((setting) =>
+            setting.id === action ? {...setting, visible} : setting,
+          );
+          setChangedTorrentContextMenuActions(nextSettings);
+          onSettingsChange({torrentContextMenuActions: nextSettings});
         },
       }))}
     />

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
@@ -1,4 +1,4 @@
-import {FC, Suspense, useEffect, useState} from 'react';
+import {FC, Suspense, useCallback, useEffect, useState} from 'react';
 import {Trans} from '@lingui/react';
 import {useInterval} from 'react-use';
 
@@ -15,10 +15,8 @@ import Size from '../../general/Size';
 
 const TorrentPeers: FC = () => {
   const [peers, setPeers] = useState<Array<TorrentPeer>>([]);
-  const [pollingDelay, setPollingDelay] = useState<number | null>(null);
 
-  const fetchPeers = () => {
-    setPollingDelay(null);
+  const fetchPeers = useCallback(() => {
     if (UIStore.activeModal?.id === 'torrent-details') {
       TorrentActions.fetchTorrentPeers(UIStore.activeModal?.hash).then((data) => {
         if (data != null) {
@@ -26,11 +24,10 @@ const TorrentPeers: FC = () => {
         }
       });
     }
-    setPollingDelay(ConfigStore.pollInterval);
-  };
+  }, []);
 
-  useEffect(() => fetchPeers(), []);
-  useInterval(() => fetchPeers(), pollingDelay);
+  useEffect(() => fetchPeers(), [fetchPeers]);
+  useInterval(fetchPeers, ConfigStore.pollInterval);
 
   return (
     <div className="torrent-details__section torrent-details__section--peers">

--- a/client/src/javascript/components/sidebar/SidebarFilter.tsx
+++ b/client/src/javascript/components/sidebar/SidebarFilter.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import {createRef, FC, ReactNode, KeyboardEvent, MouseEvent, RefObject, TouchEvent, useEffect, useState} from 'react';
+import {FC, ReactNode, KeyboardEvent, MouseEvent, RefObject, TouchEvent, useEffect, useRef, useState} from 'react';
 import {useLingui} from '@lingui/react';
 
 import {css} from '@client/styled-system/css';
@@ -15,15 +15,25 @@ const focusStyle = css({
   },
 });
 
-const useRefTextOverflowed = (ref: RefObject<HTMLElement | null>) => {
+const useRefTextOverflowed = (ref: RefObject<HTMLElement | null>, content: string) => {
   const [overflowed, setOverflowed] = useState(false);
 
   useEffect(() => {
-    if (ref.current) {
-      const {current} = ref;
-      setOverflowed(current.scrollWidth > current.clientWidth);
-    }
-  }, [ref, ref?.current?.scrollWidth, ref?.current?.clientWidth]);
+    const element = ref.current;
+    if (element == null) return undefined;
+
+    const updateOverflowed = () => {
+      setOverflowed(element.scrollWidth > element.clientWidth);
+    };
+    const animationFrameId = window.requestAnimationFrame(updateOverflowed);
+    const resizeObserver = new ResizeObserver(updateOverflowed);
+    resizeObserver.observe(element);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      resizeObserver.disconnect();
+    };
+  }, [content, ref]);
 
   return overflowed;
 };
@@ -49,11 +59,8 @@ const SidebarFilter: FC<SidebarFilterProps> = ({
   size,
   handleClick,
 }: SidebarFilterProps) => {
-  const nameSpanRef = createRef<HTMLSpanElement>();
-  const overflowed = useRefTextOverflowed(nameSpanRef);
-
+  const nameSpanRef = useRef<HTMLSpanElement>(null);
   const {i18n} = useLingui();
-
   const [expanded, setExpanded] = useState(false);
 
   const classNames = classnames('sidebar-filter__item', {
@@ -64,21 +71,26 @@ const SidebarFilter: FC<SidebarFilterProps> = ({
     expanded: expanded,
   });
 
+  let isHidden = false;
   let name = _name;
   if (name === '') {
     name = i18n._('filter.all');
   } else if (name === 'untagged') {
     if (count === 0) {
-      return null;
+      isHidden = true;
     }
     name = i18n._('filter.untagged');
   }
 
   if (slug === 'checking' || slug === 'moving' || slug === 'error') {
     if (count === 0) {
-      return null;
+      isHidden = true;
     }
   }
+
+  const overflowed = useRefTextOverflowed(nameSpanRef, name);
+
+  if (isHidden) return null;
 
   return (
     <li>

--- a/client/src/javascript/ui/components/Portal.tsx
+++ b/client/src/javascript/ui/components/Portal.tsx
@@ -1,4 +1,4 @@
-import {FC, ReactNode, useEffect, useRef} from 'react';
+import {FC, ReactNode, useEffect, useState} from 'react';
 import {createPortal} from 'react-dom';
 
 interface PortalProps {
@@ -6,33 +6,30 @@ interface PortalProps {
 }
 
 const Portal: FC<PortalProps> = ({children}: PortalProps) => {
-  const mountPoint = useRef<HTMLDivElement | null>(null);
+  const [mountPoint] = useState(() => {
+    const element = document.createElement('div');
+    element.classList.add('portal');
+    return element;
+  });
 
   useEffect(() => {
-    mountPoint.current = document.createElement('div');
-    mountPoint.current.classList.add('portal');
-
     const appElement = document.getElementById('app');
     if (appElement == null) {
-      document.body.appendChild(mountPoint.current);
+      document.body.appendChild(mountPoint);
     } else {
-      appElement.appendChild(mountPoint.current);
+      appElement.appendChild(mountPoint);
     }
 
     return () => {
-      if (mountPoint.current != null) {
-        if (appElement == null) {
-          document.body.removeChild(mountPoint.current);
-        } else {
-          appElement.removeChild(mountPoint.current);
-        }
+      if (appElement == null) {
+        document.body.removeChild(mountPoint);
+      } else {
+        appElement.removeChild(mountPoint);
       }
     };
-  }, []);
+  }, [mountPoint]);
 
-  if (mountPoint.current == null) return null;
-
-  return createPortal(children, mountPoint.current);
+  return createPortal(children, mountPoint);
 };
 
 export default Portal;

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-n": "18.2.2",
     "eslint-plugin-react": "7.37.5",
-    "eslint-plugin-react-hooks": "5.2.0",
+    "eslint-plugin-react-hooks": "^7",
     "eslint-plugin-simple-import-sort": "14.0.0",
     "eslint-plugin-storybook": "10.5.4",
     "fast-json-patch": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,8 +237,8 @@ importers:
         specifier: 7.37.5
         version: 7.37.5(eslint@9.39.5(jiti@2.6.1)(supports-color@10.2.2))
       eslint-plugin-react-hooks:
-        specifier: 5.2.0
-        version: 5.2.0(eslint@9.39.5(jiti@2.6.1)(supports-color@10.2.2))
+        specifier: ^7
+        version: 7.1.1(eslint@9.39.5(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
       eslint-plugin-simple-import-sort:
         specifier: 14.0.0
         version: 14.0.0(eslint@9.39.5(jiti@2.6.1)(supports-color@10.2.2))
@@ -4623,11 +4623,11 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-react-hooks@5.2.0:
-    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
-    engines: {node: '>=10'}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -5156,6 +5156,12 @@ packages:
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -8005,6 +8011,12 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -12372,9 +12384,16 @@ snapshots:
       ts-declaration-location: 1.0.7(@typescript/typescript6@6.0.2)
       typescript: '@typescript/typescript6@6.0.2'
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.5(jiti@2.6.1)(supports-color@10.2.2)):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.5(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/parser': 7.29.7
       eslint: 9.39.5(jiti@2.6.1)(supports-color@10.2.2)
+      hermes-parser: 0.25.1
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.6.1)(supports-color@10.2.2)):
     dependencies:
@@ -13009,6 +13028,12 @@ snapshots:
       '@types/hast': 3.0.4
 
   help-me@5.0.0: {}
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   homedir-polyfill@1.0.3:
     dependencies:
@@ -16438,6 +16463,10 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
 


### PR DESCRIPTION
## Changes

- Upgrade `eslint-plugin-react-hooks` from 5.2.0 to v7
- Fix React hooks violations detected by the new version:

### Component Fixes

1. **PriorityMeter**: Use `useCallback` and `useEffect` for ref update instead of direct mutation during render
2. **ModalTabs**: Avoid mutating tabs object, use spread operator to create new object with id
3. **TorrentContextMenuActionsList**: Replace `useRef` with `useState` for better state management
4. **TorrentPeers**: Use `useCallback` for fetchPeers function to stabilize reference
5. **SidebarFilter**: Use `useRef` + `ResizeObserver` for overflow detection instead of `createRef`
6. **Portal**: Use `useState` for mount point initialization to ensure stable reference

### Testing

- ✅ TypeScript compilation passes
- ✅ ESLint passes with 0 warnings