### PR TITLE
fix(qbittorrent): derive active/inactive from rates for forced states

### DIFF
--- a/server/services/qBittorrent/clientGatewayService.ts
+++ b/server/services/qBittorrent/clientGatewayService.ts
@@ -429,10 +429,11 @@ class QBittorrentClientGatewayService extends BaseClientGatewayService implement
               } = this.cachedProperties[info.hash] || {};
 
               const isSeeding = info.state.endsWith('UP');
+              const isTransferring = info.dlspeed > 0 || info.upspeed > 0;
               const torrentProperties: TorrentProperties = {
                 bytesDone: info.completed,
                 comment: comment,
-                dateActive: info.dlspeed > 0 || info.upspeed > 0 ? -1 : info.last_activity,
+                dateActive: isTransferring ? -1 : info.last_activity,
                 dateAdded: info.added_on,
                 dateCreated,
                 dateFinished: info.completion_on,
@@ -457,7 +458,7 @@ class QBittorrentClientGatewayService extends BaseClientGatewayService implement
                 seedsTotal: info.num_complete,
                 sizeBytes: info.total_size,
                 selectedSizeBytes: info.size,
-                status: getTorrentStatusFromState(info.state, trackerMessage),
+                status: getTorrentStatusFromState(info.state, trackerMessage, isTransferring),
                 tags: info.tags === '' ? [] : info.tags.split(',').map((tag) => tag.trim()),
                 trackerURIs,
                 upRate: info.upspeed,

--- a/server/services/qBittorrent/util/torrentPropertiesUtil.test.ts
+++ b/server/services/qBittorrent/util/torrentPropertiesUtil.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from 'vitest';
+
+import {getTorrentStatusFromState} from './torrentPropertiesUtil';
+
+describe('getTorrentStatusFromState', () => {
+  describe('forced states', () => {
+    it('reports a transferring force-seeding torrent as active', () => {
+      expect(getTorrentStatusFromState('forcedUP', '', true)).toEqual(['complete', 'active', 'seeding']);
+    });
+
+    it('reports an idle force-seeding torrent as inactive', () => {
+      expect(getTorrentStatusFromState('forcedUP', '', false)).toEqual(['complete', 'inactive', 'seeding']);
+    });
+
+    it('reports a transferring force-downloading torrent as active', () => {
+      expect(getTorrentStatusFromState('forcedDL', '', true)).toEqual(['active', 'downloading']);
+    });
+
+    it('reports an idle force-downloading torrent as inactive', () => {
+      expect(getTorrentStatusFromState('forcedDL', '', false)).toEqual(['inactive', 'downloading']);
+    });
+
+    it('keeps force-seeding torrents in the seeding taxonomy either way', () => {
+      expect(getTorrentStatusFromState('forcedUP', '', true)).toContain('seeding');
+      expect(getTorrentStatusFromState('forcedUP', '', false)).toContain('seeding');
+    });
+  });
+
+  describe('states that already encode their own activity', () => {
+    it('ignores the rate for uploading, which qBittorrent only reports when the rate is positive', () => {
+      expect(getTorrentStatusFromState('uploading', '', false)).toEqual(['complete', 'active', 'seeding']);
+    });
+
+    it('ignores the rate for stalledUP, which qBittorrent only reports when the rate is zero', () => {
+      expect(getTorrentStatusFromState('stalledUP', '', true)).toEqual(['complete', 'inactive', 'seeding']);
+    });
+
+    it('ignores the rate for downloading', () => {
+      expect(getTorrentStatusFromState('downloading', '', false)).toEqual(['active', 'downloading']);
+    });
+
+    it('ignores the rate for stalledDL', () => {
+      expect(getTorrentStatusFromState('stalledDL', '', true)).toEqual(['inactive', 'downloading']);
+    });
+
+    it('keeps queued torrents inactive regardless of rate', () => {
+      expect(getTorrentStatusFromState('queuedUP', '', true)).toEqual(['complete', 'inactive', 'seeding']);
+      expect(getTorrentStatusFromState('queuedDL', '', true)).toEqual(['inactive', 'downloading']);
+    });
+
+    it('keeps stopped torrents inactive regardless of rate', () => {
+      expect(getTorrentStatusFromState('stoppedUP', '', true)).toEqual(['complete', 'inactive', 'stopped']);
+      expect(getTorrentStatusFromState('stoppedDL', '', true)).toEqual(['inactive', 'stopped']);
+    });
+  });
+
+  describe('tracker messages', () => {
+    it('appends warning without disturbing the activity flag', () => {
+      expect(getTorrentStatusFromState('forcedUP', 'tracker is down', true)).toEqual([
+        'complete',
+        'active',
+        'seeding',
+        'warning',
+      ]);
+    });
+  });
+
+  describe('defaults', () => {
+    it('treats an omitted rate as not transferring', () => {
+      expect(getTorrentStatusFromState('forcedUP')).toEqual(['complete', 'inactive', 'seeding']);
+    });
+  });
+});

--- a/server/services/qBittorrent/util/torrentPropertiesUtil.ts
+++ b/server/services/qBittorrent/util/torrentPropertiesUtil.ts
@@ -25,9 +25,19 @@ export const getTorrentTrackerTypeFromURL = (url: string): TorrentTracker['type'
   return TorrentTrackerType.DHT;
 };
 
+/**
+ * qBittorrent resolves `isForced()` before it tests the payload rate
+ * (`TorrentImpl::updateState`), so a force-started torrent is reported as
+ * `forcedUP`/`forcedDL` whether or not it is transferring - the rate-bearing
+ * `uploading`/`stalledUP` and `downloading`/`stalledDL` states are unreachable
+ * for it. Those two states therefore cannot imply activity on their own, and
+ * `isTransferring` is used instead, matching how the rTorrent backend derives
+ * `active`/`inactive` from the observed rates.
+ */
 export const getTorrentStatusFromState = (
   state: QBittorrentTorrentState,
   trackerMessage = '',
+  isTransferring = false,
 ): TorrentProperties['status'] => {
   const statuses: TorrentProperties['status'] = [];
 
@@ -51,9 +61,13 @@ export const getTorrentStatusFromState = (
       break;
     case 'queuedUP':
     case 'stalledUP':
-    case 'forcedUP':
       statuses.push('complete');
       statuses.push('inactive');
+      statuses.push('seeding');
+      break;
+    case 'forcedUP':
+      statuses.push('complete');
+      statuses.push(isTransferring ? 'active' : 'inactive');
       statuses.push('seeding');
       break;
     case 'checkingUP':
@@ -67,8 +81,11 @@ export const getTorrentStatusFromState = (
     case 'metaDL':
     case 'forcedMetaDL':
     case 'downloading':
-    case 'forcedDL':
       statuses.push('active');
+      statuses.push('downloading');
+      break;
+    case 'forcedDL':
+      statuses.push(isTransferring ? 'active' : 'inactive');
       statuses.push('downloading');
       break;
     case 'pausedDL':


### PR DESCRIPTION
Fixes #1345.

## Why

`getTorrentStatusFromState` derives `active`/`inactive` for the qBittorrent backend from the state string alone. That works for most states, but not for the two forced ones.

qBittorrent resolves `isForced()` **before** it tests the payload rate in `TorrentImpl::updateState`, so `Uploading`/`StalledUploading` and `Downloading`/`StalledDownloading` are unreachable for a force-started torrent — `forcedUP` and `forcedDL` each cover both the transferring and the idle case. The state string does not carry the information, so no mapping from it alone can be correct.

The result is that a force-seeding torrent is reported `inactive` while it is uploading (and never matches the `Active` filter), and an idle force-started download is reported `active`. `upRate`/`downRate` are correct throughout, which is what makes `status` visibly inconsistent with the rest of the record.

Size: XS

## Acceptance criteria

- `forcedUP` reports `active` when the torrent is transferring and `inactive` when it is not, and stays in the `seeding` taxonomy either way.
- `forcedDL` reports `active` when transferring and `inactive` when not, and stays in the `downloading` taxonomy either way.
- States that already encode their own activity are unchanged: `uploading`, `stalledUP`, `downloading`, `stalledDL`, `queuedUP`, `queuedDL`, `stoppedUP`, `stoppedDL`, `checkingUP`, `checkingDL`, `metaDL`, `forcedMetaDL`, `error`, `missingFiles`, `moving`, `checkingResumeData`, `unknown`.
- The `warning` status from a tracker message is still appended independently of the activity flag.
- Behaviour matches the rTorrent backend, which already derives the flag from observed rates.

## What changed

- `getTorrentStatusFromState` takes an `isTransferring` argument (defaulting to `false`, so existing callers keep their current behaviour) and uses it for `forcedUP` and `forcedDL` only. `forcedUP` is split out of the `queuedUP`/`stalledUP` case, and `forcedDL` out of the `metaDL`/`forcedMetaDL`/`downloading` case.
- The call site in `clientGatewayService.ts` hoists the `info.dlspeed > 0 || info.upspeed > 0` predicate it already computed for `dateActive` into a local `isTransferring` and passes it through, so no extra request or field is needed.
- New unit tests for the mapping.

## Test plan

- `pnpm run check-types` — clean
- `pnpm run lint` — clean (`--max-warnings 0`)
- `pnpm exec prettier -c` on the touched files — clean
- 13 new unit tests in `server/services/qBittorrent/util/torrentPropertiesUtil.test.ts`, covering both forced states in both directions, the states that must stay rate-independent, the `warning` append, and the default argument. All pass.
- Verified against a real qBittorrent 5.2.1 instance: captured a live `/api/v2/torrents/info` payload of 67 force-seeding torrents, 2 of which were uploading at the time (84,682 B/s and 1,318 B/s), and replayed it through the old and new mapping. Exactly those 2 flipped `[complete,inactive,seeding]` to `[complete,active,seeding]`; the other 65 were untouched.

The pre-existing integration projects spawn real torrent-client binaries, so I was not able to run them locally — the new tests are pure unit tests over the mapping function and need no client.

## Out of scope

- The `active`/`inactive` derivation for the other backends.
- Any change to how the `Active`/`Inactive` sidebar filters are computed from `status`.
- `metaDL`/`forcedMetaDL`, which are a metadata fetch rather than a payload transfer and keep reporting `active`.
