### PR TITLE
fix: Neptune torrent added time showing as 58512 years

### DIFF
--- a/server/services/Neptune/clientGatewayService.ts
+++ b/server/services/Neptune/clientGatewayService.ts
@@ -292,7 +292,7 @@ class NeptuneClientGatewayService extends ClientGatewayService {
             bytesDone: torrent.completed,
             comment: torrent.comment,
             dateActive: 0,
-            dateAdded: torrent.add_at,
+            dateAdded: torrent.add_at / 1000,
             dateCreated: 0,
             dateFinished: torrent.completed_at,
             directory: torrent.directory_base,


### PR DESCRIPTION
## Problem

Neptune API returns `add_at` in milliseconds (UnixMilli), but Flood's `dateAdded` expects seconds. This causes the added time to display as ~58512 years.

## Fix

Divide `torrent.add_at` by 1000 to convert milliseconds to seconds, matching how the frontend uses it: `new Date(torrent.dateAdded * 1000)`.