### PR TITLE
fix(client): reflect file priority changes in torrent details list

### DIFF
--- a/client/src/javascript/components/general/filesystem/DirectoryFileList.tsx
+++ b/client/src/javascript/components/general/filesystem/DirectoryFileList.tsx
@@ -6,7 +6,11 @@ import {Checkmark, Clipboard, File as FileIcon} from '@client/ui/icons';
 import ConfigStore from '@client/stores/ConfigStore';
 import TorrentActions from '@client/actions/TorrentActions';
 
-import type {TorrentContentSelection, TorrentContentSelectionTree} from '@shared/types/TorrentContent';
+import type {
+  TorrentContentPriority,
+  TorrentContentSelection,
+  TorrentContentSelectionTree,
+} from '@shared/types/TorrentContent';
 import type {TorrentProperties} from '@shared/types/Torrent';
 
 import PriorityMeter from '../PriorityMeter';
@@ -18,9 +22,17 @@ interface DirectoryFilesProps {
   items: TorrentContentSelectionTree['files'];
   path: Array<string>;
   onItemSelect: (selection: TorrentContentSelection) => void;
+  onPriorityChange: (index: number, priority: TorrentContentPriority) => void;
 }
 
-const DirectoryFiles: FC<DirectoryFilesProps> = ({depth, items, hash, path, onItemSelect}: DirectoryFilesProps) => {
+const DirectoryFiles: FC<DirectoryFilesProps> = ({
+  depth,
+  items,
+  hash,
+  path,
+  onItemSelect,
+  onPriorityChange,
+}: DirectoryFilesProps) => {
   const [copiedToClipboard, setCopiedToClipboard] = useState<number | null>(null);
   const contentPermalinks = useRef<Record<number, string | null>>({});
 
@@ -83,15 +95,12 @@ const DirectoryFiles: FC<DirectoryFilesProps> = ({depth, items, hash, path, onIt
             file__detail--priority"
           >
             <PriorityMeter
-              key={`${file.index}-${file.filename}`}
+              key={`${file.index}-${file.filename}-${file.priority}`}
               level={file.priority}
               id={file.index}
               maxLevel={2}
               onChange={(fileIndex: string | number, priorityLevel: number) =>
-                TorrentActions.setFilePriority(hash, {
-                  indices: [Number(fileIndex)],
-                  priority: priorityLevel,
-                })
+                onPriorityChange(Number(fileIndex), priorityLevel)
               }
               priorityType="file"
             />

--- a/client/src/javascript/components/general/filesystem/DirectoryTree.tsx
+++ b/client/src/javascript/components/general/filesystem/DirectoryTree.tsx
@@ -1,6 +1,10 @@
 import {FC, ReactNode} from 'react';
 
-import type {TorrentContentSelection, TorrentContentSelectionTree} from '@shared/types/TorrentContent';
+import type {
+  TorrentContentPriority,
+  TorrentContentSelection,
+  TorrentContentSelectionTree,
+} from '@shared/types/TorrentContent';
 import type {TorrentProperties} from '@shared/types/Torrent';
 
 import DirectoryFileList from './DirectoryFileList';
@@ -13,10 +17,11 @@ interface DirectoryTreeProps {
   hash: TorrentProperties['hash'];
   itemsTree: TorrentContentSelectionTree;
   onItemSelect: (selection: TorrentContentSelection) => void;
+  onPriorityChange: (index: number, priority: TorrentContentPriority) => void;
 }
 
 const DirectoryTree: FC<DirectoryTreeProps> = (props: DirectoryTreeProps) => {
-  const {depth = 0, itemsTree, hash, path, onItemSelect} = props;
+  const {depth = 0, itemsTree, hash, path, onItemSelect, onPriorityChange} = props;
   const {files, directories} = itemsTree;
   const childDepth = depth + 1;
 
@@ -44,6 +49,7 @@ const DirectoryTree: FC<DirectoryTreeProps> = (props: DirectoryTreeProps) => {
                 key={id}
                 itemsTree={subSelectedItems}
                 onItemSelect={onItemSelect}
+                onPriorityChange={onPriorityChange}
                 path={path}
               />
             );
@@ -57,6 +63,7 @@ const DirectoryTree: FC<DirectoryTreeProps> = (props: DirectoryTreeProps) => {
         hash={hash}
         key={`files-${childDepth}`}
         onItemSelect={onItemSelect}
+        onPriorityChange={onPriorityChange}
         path={path}
         items={itemsTree.files}
       />

--- a/client/src/javascript/components/general/filesystem/DirectoryTreeNode.tsx
+++ b/client/src/javascript/components/general/filesystem/DirectoryTreeNode.tsx
@@ -5,7 +5,11 @@ import {css} from '@client/styled-system/css';
 import {Checkbox} from '@client/ui';
 import {FolderClosedSolid, FolderOpenSolid} from '@client/ui/icons';
 
-import type {TorrentContentSelection, TorrentContentSelectionTree} from '@shared/types/TorrentContent';
+import type {
+  TorrentContentPriority,
+  TorrentContentSelection,
+  TorrentContentSelectionTree,
+} from '@shared/types/TorrentContent';
 import type {TorrentProperties} from '@shared/types/Torrent';
 
 // TODO: Fix this circular dependency
@@ -20,6 +24,7 @@ interface DirectoryTreeNodeProps {
   itemsTree: TorrentContentSelectionTree;
   isSelected: boolean;
   onItemSelect: (selection: TorrentContentSelection) => void;
+  onPriorityChange: (index: number, priority: TorrentContentPriority) => void;
 }
 
 const DirectoryTreeNode: FC<DirectoryTreeNodeProps> = ({
@@ -31,6 +36,7 @@ const DirectoryTreeNode: FC<DirectoryTreeNodeProps> = ({
   path,
   isSelected,
   onItemSelect,
+  onPriorityChange,
 }: DirectoryTreeNodeProps) => {
   const [expanded, setExpanded] = useState<boolean>(false);
   const currentPath = [...path, directoryName];
@@ -100,6 +106,7 @@ const DirectoryTreeNode: FC<DirectoryTreeNodeProps> = ({
             hash={hash}
             key={`${expanded}-${depth}`}
             onItemSelect={onItemSelect}
+            onPriorityChange={onPriorityChange}
             path={currentPath}
             itemsTree={itemsTree}
           />

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentContents.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentContents.tsx
@@ -11,7 +11,12 @@ import TorrentActions from '@client/actions/TorrentActions';
 import TorrentStore from '@client/stores/TorrentStore';
 import UIStore from '@client/stores/UIStore';
 
-import type {TorrentContent, TorrentContentSelection, TorrentContentSelectionTree} from '@shared/types/TorrentContent';
+import type {
+  TorrentContent,
+  TorrentContentPriority,
+  TorrentContentSelection,
+  TorrentContentSelectionTree,
+} from '@shared/types/TorrentContent';
 
 import DirectoryTree from '../../general/filesystem/DirectoryTree';
 
@@ -19,6 +24,7 @@ const TorrentContents: FC = observer(() => {
   const [contents, setContents] = useState<TorrentContent[]>([]);
   const [itemsTree, setItemsTree] = useState<TorrentContentSelectionTree>({});
   const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
+  const [prioritySelectToken, setPrioritySelectToken] = useState<number>(0);
   const {i18n} = useLingui();
 
   useEffect(() => {
@@ -37,6 +43,19 @@ const TorrentContents: FC = observer(() => {
   }
 
   const {hash} = UIStore.activeModal;
+
+  const setPriority = (indices: number[], priority: TorrentContentPriority) => {
+    if (indices.length === 0) {
+      return;
+    }
+
+    TorrentActions.setFilePriority(hash, {indices, priority});
+
+    setContents((currentContents) =>
+      currentContents.map((content) => (indices.includes(content.index) ? {...content, priority} : content)),
+    );
+    setItemsTree((currentItemsTree) => selectionTree.applyPriority(currentItemsTree, indices, priority));
+  };
 
   let directoryHeadingIconContent = null;
   let fileDetailContent = null;
@@ -80,6 +99,7 @@ const TorrentContents: FC = observer(() => {
           setItemsTree(newItemsTree);
           setSelectedIndices(selectionTree.getSelectedItems(newItemsTree));
         }}
+        onPriorityChange={(index, priority) => setPriority([index], priority)}
         hash={hash}
         path={[]}
         itemsTree={itemsTree}
@@ -122,10 +142,8 @@ const TorrentContents: FC = observer(() => {
         if (event.target != null && (event.target as HTMLInputElement).name === 'file-priority') {
           const inputElement = event.target as HTMLInputElement;
           if (inputElement.value) {
-            TorrentActions.setFilePriority(hash, {
-              indices: selectedIndices,
-              priority: Number(inputElement.value),
-            });
+            setPriority(selectedIndices, Number(inputElement.value));
+            setPrioritySelectToken((token) => token + 1);
           }
         }
       }}
@@ -167,7 +185,7 @@ const TorrentContents: FC = observer(() => {
               }}
             />
           </Button>
-          <Select id="file-priority" persistentPlaceholder shrink={false} defaultID="">
+          <Select id="file-priority" key={prioritySelectToken} persistentPlaceholder shrink={false} defaultID="">
             <SelectItem id={-1} isPlaceholder>
               <Trans id="torrents.details.selected.files.set.priority" />
             </SelectItem>

--- a/client/src/javascript/util/selectionTree.ts
+++ b/client/src/javascript/util/selectionTree.ts
@@ -1,4 +1,9 @@
-import type {TorrentContent, TorrentContentSelection, TorrentContentSelectionTree} from '@shared/types/TorrentContent';
+import type {
+  TorrentContent,
+  TorrentContentPriority,
+  TorrentContentSelection,
+  TorrentContentSelectionTree,
+} from '@shared/types/TorrentContent';
 
 const selectAll = (tree: TorrentContentSelectionTree, isSelected: boolean): TorrentContentSelectionTree => ({
   ...tree,
@@ -155,9 +160,44 @@ const getSelectionTree = (contents: Array<TorrentContent>, isSelected = false): 
   return tree;
 };
 
+const applyPriorityToIndices = (
+  tree: TorrentContentSelectionTree,
+  indices: Set<number>,
+  priority: TorrentContentPriority,
+): TorrentContentSelectionTree => ({
+  ...tree,
+  ...(tree.directories != null
+    ? {
+        directories: Object.fromEntries(
+          Object.entries(tree.directories).map(([directory, subTree]) => [
+            directory,
+            applyPriorityToIndices(subTree, indices, priority),
+          ]),
+        ),
+      }
+    : {}),
+  ...(tree.files != null
+    ? {
+        files: Object.fromEntries(
+          Object.entries(tree.files).map(([fileName, file]) => [
+            fileName,
+            indices.has(file.index) ? {...file, priority} : file,
+          ]),
+        ),
+      }
+    : {}),
+});
+
+const applyPriority = (
+  tree: TorrentContentSelectionTree,
+  indices: Array<number>,
+  priority: TorrentContentPriority,
+): TorrentContentSelectionTree => applyPriorityToIndices(tree, new Set(indices), priority);
+
 const selectionTree = {
   selectAll,
   applySelection,
+  applyPriority,
   getSelectedItems,
   getSelectionTree,
 };


### PR DESCRIPTION
## Description

Setting a priority on a multi-file selection in the torrent details Contents tab applied on the
backend, but the file list kept showing the old priorities. `TorrentContents` fetches contents once
and never updated them after a change; `PriorityMeter` only reads `level` on mount; and `Select`
doesn't re-fire for an unchanged value, so re-applying the same priority did nothing at all.

Adds `selectionTree.applyPriority()` and a `setPriority()` in `TorrentContents` that updates
`contents` and `itemsTree` alongside the request, threaded down to the per-file meters via
`onPriorityChange`. The meter's key now includes `file.priority`, and the `<Select>` resets after
each apply.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)