### PR TITLE
feat(torrent-details): add sortable peer columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ pnpm test -- --project transmission
 pnpm test -- --project auth
 ```
 
+> **Note**: `vitest.config.mts` only configures backend (`server/`) integration test projects. The frontend (`client/`) does not use Vitest — frontend tests are covered by Storybook interaction tests (`pnpm run test-storybook`). Do not add Vitest projects or `.test.ts` unit tests for client code.
+
 ## Critical Architectural Patterns
 
 ### Frontend State Management

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.stories.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.stories.tsx
@@ -1,0 +1,77 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {within, expect, userEvent, waitFor} from 'storybook/test';
+
+import TorrentPeers from './TorrentPeers';
+import UIStore from '@client/stores/UIStore';
+
+const meta: Meta<typeof TorrentPeers> = {
+  title: 'Components/TorrentPeers',
+  component: TorrentPeers,
+  parameters: {
+    layout: 'padded',
+  },
+  loaders: [
+    async () => {
+      UIStore.setActiveModal({id: 'torrent-details', hash: 'MOCKHASH'});
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sortable: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // Mock data: 192.168.1.100 (dl 524288, ul 262144, 45%), 10.0.0.50 (dl 0, ul 1MiB, 100%), 172.16.0.25 (dl 102400, ul 51200, 78%)
+    await waitFor(() => {
+      expect(canvas.getByText('192.168.1.100:51234')).toBeInTheDocument();
+    });
+
+    const getRowTexts = () =>
+      canvas
+        .getAllByRole('row')
+        .slice(1)
+        .map((row) => row.textContent);
+
+    // Initial order matches the backend response
+    expect(getRowTexts()[0]).toContain('192.168.1.100:51234');
+    expect(getRowTexts()[1]).toContain('10.0.0.50:49999');
+    expect(getRowTexts()[2]).toContain('172.16.0.25:6881');
+
+    // Click DL heading -> sort by downloadRate in descending order
+    await userEvent.click(canvas.getByRole('button', {name: 'DL'}));
+    await waitFor(() => {
+      expect(getRowTexts()[0]).toContain('192.168.1.100:51234');
+      expect(getRowTexts()[1]).toContain('172.16.0.25:6881');
+      expect(getRowTexts()[2]).toContain('10.0.0.50:49999');
+    });
+
+    // Click DL heading again -> toggle to ascending order
+    await userEvent.click(canvas.getByRole('button', {name: 'DL'}));
+    await waitFor(() => {
+      expect(getRowTexts()[0]).toContain('10.0.0.50:49999');
+      expect(getRowTexts()[1]).toContain('172.16.0.25:6881');
+      expect(getRowTexts()[2]).toContain('192.168.1.100:51234');
+    });
+
+    // Click UL heading -> sort by uploadRate in descending order
+    await userEvent.click(canvas.getByRole('button', {name: 'UL'}));
+    await waitFor(() => {
+      expect(getRowTexts()[0]).toContain('10.0.0.50:49999');
+      expect(getRowTexts()[1]).toContain('192.168.1.100:51234');
+      expect(getRowTexts()[2]).toContain('172.16.0.25:6881');
+    });
+
+    // Click % heading -> sort by completedPercent in descending order
+    await userEvent.click(canvas.getByRole('button', {name: '%'}));
+    await waitFor(() => {
+      expect(getRowTexts()[0]).toContain('10.0.0.50:49999');
+      expect(getRowTexts()[1]).toContain('172.16.0.25:6881');
+      expect(getRowTexts()[2]).toContain('192.168.1.100:51234');
+    });
+  },
+};

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx
@@ -1,4 +1,5 @@
-import {FC, Suspense, useCallback, useEffect, useState} from 'react';
+import classnames from 'classnames';
+import {FC, ReactNode, Suspense, useCallback, useEffect, useMemo, useState} from 'react';
 import {Trans} from '@lingui/react';
 import {useInterval} from 'react-use';
 
@@ -7,6 +8,8 @@ import {CheckmarkThick, CountryFlag, Lock, Spinner} from '@client/ui/icons';
 import ConfigStore from '@client/stores/ConfigStore';
 import TorrentActions from '@client/actions/TorrentActions';
 import UIStore from '@client/stores/UIStore';
+import sortPeers from '@client/util/sortPeers';
+import type {PeerSortBy, PeerSortProperty} from '@client/util/sortPeers';
 
 import type {TorrentPeer} from '@shared/types/TorrentPeer';
 
@@ -15,6 +18,7 @@ import Size from '../../general/Size';
 
 const TorrentPeers: FC = () => {
   const [peers, setPeers] = useState<Array<TorrentPeer>>([]);
+  const [sortBy, setSortBy] = useState<PeerSortBy | null>(null);
 
   const fetchPeers = useCallback(() => {
     if (UIStore.activeModal?.id === 'torrent-details') {
@@ -28,6 +32,37 @@ const TorrentPeers: FC = () => {
 
   useEffect(() => fetchPeers(), [fetchPeers]);
   useInterval(fetchPeers, ConfigStore.pollInterval);
+
+  const sortedPeers = useMemo(() => (sortBy == null ? peers : sortPeers(peers, sortBy)), [peers, sortBy]);
+
+  const handleSort = (property: PeerSortProperty) => {
+    setSortBy((current) => {
+      if (current?.property === property) {
+        return {property, direction: current.direction === 'asc' ? 'desc' : 'asc'};
+      }
+      return {property, direction: 'desc'};
+    });
+  };
+
+  const renderHeading = (property: PeerSortProperty, label: ReactNode) => {
+    const isSorted = sortBy?.property === property;
+    const classes = classnames(
+      'torrent-details__table__heading--secondary',
+      'torrent-details__table__heading--sortable',
+      {
+        'torrent-details__table__heading--is-sorted': isSorted,
+        [`torrent-details__table__heading--direction--${sortBy?.direction}`]: isSorted,
+      },
+    );
+
+    return (
+      <th aria-sort={isSorted ? (sortBy.direction === 'asc' ? 'ascending' : 'descending') : 'none'} scope="col">
+        <button className={classes} type="button" onClick={() => handleSort(property)}>
+          {label}
+        </button>
+      </th>
+    );
+  };
 
   return (
     <div className="torrent-details__section torrent-details__section--peers">
@@ -47,16 +82,16 @@ const TorrentPeers: FC = () => {
               <Trans id="torrents.details.peers" />
               <Badge>{peers.length}</Badge>
             </th>
-            <th className="torrent-details__table__heading--secondary">DL</th>
-            <th className="torrent-details__table__heading--secondary">UL</th>
-            <th className="torrent-details__table__heading--secondary">%</th>
+            {renderHeading('downloadRate', 'DL')}
+            {renderHeading('uploadRate', 'UL')}
+            {renderHeading('completedPercent', '%')}
             <th className="torrent-details__table__heading--secondary">Client</th>
             <th className="torrent-details__table__heading--secondary">Enc</th>
             <th className="torrent-details__table__heading--secondary">In</th>
           </tr>
         </thead>
         <tbody>
-          {peers.map((peer) => {
+          {sortedPeers.map((peer) => {
             const {country: countryCode} = peer;
             const encryptedIcon = peer.isEncrypted ? <Lock /> : null;
             const incomingIcon = peer.isIncoming ? <CheckmarkThick /> : null;

--- a/client/src/javascript/util/sortPeers.ts
+++ b/client/src/javascript/util/sortPeers.ts
@@ -1,0 +1,18 @@
+import {sort} from 'fast-sort';
+
+import type {TorrentPeer} from '@shared/types/TorrentPeer';
+
+export type PeerSortDirection = 'asc' | 'desc';
+
+export type PeerSortProperty = 'downloadRate' | 'uploadRate' | 'completedPercent';
+
+export interface PeerSortBy {
+  property: PeerSortProperty;
+  direction: PeerSortDirection;
+}
+
+function sortPeers(peers: TorrentPeer[], sortBy: Readonly<PeerSortBy>): TorrentPeer[] {
+  return sortBy.direction === 'asc' ? sort(peers).asc(sortBy.property) : sort(peers).desc(sortBy.property);
+}
+
+export default sortPeers;

--- a/client/src/sass/components/_torrent-details-panel.scss
+++ b/client/src/sass/components/_torrent-details-panel.scss
@@ -3,6 +3,7 @@
 
 @use '../tools/variables';
 @use '../tools/colors';
+@use '../tools/themes';
 
 @use '../ui/config/spacing.scss';
 
@@ -165,6 +166,41 @@ $torrent-details--tags--foreground: #1a2028;
     width: 100%;
 
     &__heading {
+      &--sortable {
+        background: none;
+        border: 0;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: inherit;
+        font-weight: inherit;
+        padding: 0;
+        text-align: left;
+        user-select: none;
+        white-space: nowrap;
+
+        &:focus-visible,
+        &:hover {
+          @include themes.theme('color', 'table--heading--color--hover');
+        }
+
+        &:after {
+          border-left: 4px solid transparent;
+          border-right: 4px solid transparent;
+          border-top: 5px solid currentColor;
+          content: '';
+          display: inline-block;
+          margin-left: math.div(variables.$spacing-unit * 1, 10);
+          opacity: 0;
+          transition:
+            opacity 0.2s,
+            transform 0.2s;
+        }
+
+        &:hover:after {
+          opacity: 0.5;
+        }
+      }
+
       &--primary {
         color: $torrent-details--directory-tree--parent-directory--foreground;
         font-size: 1.125em;
@@ -180,6 +216,24 @@ $torrent-details--tags--foreground: #1a2028;
       &--tertiary {
         color: $torrent-details--detail--heading--foreground;
         font-weight: 700;
+      }
+
+      &--is-sorted {
+        @include themes.theme('color', 'table--heading--color--active');
+        font-weight: 700;
+
+        &:focus-visible,
+        &:hover {
+          @include themes.theme('color', 'table--heading--color--active--hover');
+        }
+
+        &:after {
+          opacity: 0.5;
+        }
+      }
+
+      &--direction--asc:after {
+        transform: rotate(180deg);
       }
     }
   }


### PR DESCRIPTION
close https://github.com/jesec/flood/pull/610

## Description

Adds column sorting to the torrent peers table in the torrent details modal. Previously the table could only be sorted by the order returned from the backend; now DL/UL/% columns are sortable.

- Click a column heading to sort, click again to toggle ascending/descending
- Sort state is kept in local component state (not persisted to user settings)
- Sortable columns: DL (`downloadRate`), UL (`uploadRate`), % (`completedPercent`), defaulting to descending on first click
- All other columns remain static

## Changes

- `client/src/javascript/util/sortPeers.ts`: pure sort helper based on `fast-sort`
- `client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.tsx`: sortable column headings with `aria-sort`, derived sorted list via `useMemo`
- `client/src/sass/components/_torrent-details-panel.scss`: sort indicator styles matching the torrent list headings
- `client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.stories.tsx`: Storybook interaction test covering default order and DL/UL/% sorting
- `AGENTS.md`: document that `vitest.config.mts` is backend-only; frontend tests use Storybook

## Test plan

- `pnpm run check-types`, `pnpm run lint`, `pnpm run check-source-formatting` pass locally
- CI runs `check` and `test-storybook` workflows