### PR TITLE
fix(client): make torrent list viewport fill available vertical space

### DIFF
--- a/client/src/javascript/components/general/ListViewport.tsx
+++ b/client/src/javascript/components/general/ListViewport.tsx
@@ -83,7 +83,7 @@ const ListViewport = forwardRef<ListImperativeAPI, ListViewportProps>((props: Li
   }, [listElement]);
 
   return (
-    <div className={className} ref={hostElementRef} style={{height: Math.max(rowHeight * 30, 600), width: '100%'}}>
+    <div className={className} ref={hostElementRef} style={{flex: '1 1 auto', minHeight: 0, width: '100%'}}>
       <List
         defaultHeight={Math.max(rowHeight * 30, 600)}
         rowCount={rowCount}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the torrent list view no longer filling the available vertical space on large viewports (introduced by the react-window v2 upgrade in #1260).

The previous implementation sized the viewport as `height: Math.max(rowHeight * 30, 600)`, a fixed value. Combined with the `justify-content: center` on `.torrent__list__wrapper`, this caused the list to be vertically centered with empty space above and below whenever the viewport height exceeded the fixed height (e.g. 5120×2160 monitors, page height > 950px).

The outer container now participates in the flex layout (`flex: 1 1 auto`, `min-height: 0`) so it fills the remaining vertical space below the table heading. react-window v2's `List` container already has `flex-grow: 1`, `max-height: 100%` and `overflow-y: auto`, and observes its container size via `ResizeObserver`, so it adapts to the computed height automatically. `defaultHeight` is kept as the initial render value to avoid a flash of unstyled content.

## Related Issue

Fixes #1362

## Screenshots

<!--- Optional -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
