### PR TITLE
fix(ui): sync torrent list heading with horizontal scroll

### DIFF
--- a/client/src/javascript/components/general/ListViewport.tsx
+++ b/client/src/javascript/components/general/ListViewport.tsx
@@ -14,10 +14,11 @@ interface ListViewportProps {
   rowComponent: (props: RowComponentProps) => React.ReactElement | null;
   rowHeight: number;
   listRef?: React.Ref<ListImperativeAPI>;
+  onScroll?: (scrollLeft: number) => void;
 }
 
 const ListViewport = forwardRef<ListImperativeAPI, ListViewportProps>((props: ListViewportProps, ref) => {
-  const {className, rowCount, rowComponent, rowHeight, listRef} = props;
+  const {className, rowCount, rowComponent, rowHeight, listRef, onScroll} = props;
   const hostElementRef = useRef<HTMLDivElement>(null);
   const [listElement, setListElement] = useState<HTMLDivElement | null>(null);
 
@@ -81,6 +82,19 @@ const ListViewport = forwardRef<ListImperativeAPI, ListViewportProps>((props: Li
       osInstance.destroy();
     };
   }, [listElement]);
+
+  // The list element is the horizontal scroll container. Report its scroll
+  // position so callers can keep related elements (e.g. the table heading) in sync.
+  useEffect(() => {
+    if (listElement == null || onScroll == null) return;
+
+    const handleScroll = () => onScroll(listElement.scrollLeft);
+    listElement.addEventListener('scroll', handleScroll, {passive: true});
+
+    return () => {
+      listElement.removeEventListener('scroll', handleScroll);
+    };
+  }, [listElement, onScroll]);
 
   return (
     <div className={className} ref={hostElementRef} style={{flex: '1 1 auto', minHeight: 0, width: '100%'}}>

--- a/client/src/javascript/components/torrent-list/TorrentList.tsx
+++ b/client/src/javascript/components/torrent-list/TorrentList.tsx
@@ -1,4 +1,4 @@
-import {FC, KeyboardEvent, ReactNode, useEffect, useRef} from 'react';
+import {FC, KeyboardEvent, ReactNode, useCallback, useEffect, useRef} from 'react';
 import {observer} from 'mobx-react-lite';
 import {reaction} from 'mobx';
 import {Trans} from '@lingui/react';
@@ -83,6 +83,13 @@ const TorrentList: FC = observer(() => {
   const isCondensed = torrentListViewSize === 'condensed';
   const isListEmpty = torrents == null || torrents.length === 0;
 
+  // Keep the table heading horizontally in sync with the list viewport.
+  const handleListViewportScroll = useCallback((scrollLeft: number) => {
+    if (listHeaderRef.current != null) {
+      listHeaderRef.current.scrollLeft = scrollLeft;
+    }
+  }, []);
+
   let content: ReactNode = null;
   let torrentListHeading: ReactNode = null;
   if (!ClientStatusStore.isConnected) {
@@ -118,7 +125,12 @@ const TorrentList: FC = observer(() => {
       torrentListHeading = (
         <TableHeading
           onCellFocus={() => {
-            // Scroll sync removed in react-window v2
+            // Keep the viewport in sync when a heading cell is focused
+            // (e.g. via keyboard tabbing), mirroring the heading's scroll position.
+            const viewportElement = listViewportRef.current?.element;
+            if (viewportElement != null && listHeaderRef.current != null) {
+              viewportElement.scrollLeft = listHeaderRef.current.scrollLeft;
+            }
           }}
           onCellClick={(property: TorrentListColumn) => {
             const currentSort = SettingStore.floodSettings.sortTorrents;
@@ -157,6 +169,7 @@ const TorrentList: FC = observer(() => {
         rowComponent={TorrentListRowRenderer}
         rowHeight={isCondensed ? 30 : 70}
         listRef={listViewportRef}
+        onScroll={handleListViewportScroll}
       />
     );
   }


### PR DESCRIPTION
## Description

Fixes #1366.

The react-window v1 to v2 migration (#1260) removed the scroll sync between the list viewport and the column heading row. As a result, horizontally scrolling the torrent list moves the rows but leaves the heading fixed, making it impossible to sort off-screen columns.

This PR restores the sync:

- `ListViewport` gains an optional `onScroll` prop that reports the horizontal scroll position of the list element (the actual scroll container).
- `TorrentList` mirrors that `scrollLeft` onto the heading row (`.table__row--heading`), and restores the reverse sync on heading cell focus (keyboard tabbing) via `listViewportRef.current?.element.scrollLeft`.

## Related Issue

Closes #1366

## Screenshots

N/A

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)